### PR TITLE
Limit the amount of randomness added by AutoName

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -9,6 +9,9 @@ import (
 	"github.com/pulumi/pulumi-fabric/pkg/util/contract"
 )
 
+// RandomHexSuffixLength is the length of the suffix added AutoName properties by default.
+const RandomHexSuffixLength = 8
+
 // LumiToTerraformName performs a standard transformation on the given name string, from Lumi's PascalCasing or
 // camelCasing, to Terraform's underscore_casing.
 func LumiToTerraformName(name string) string {
@@ -86,7 +89,7 @@ func AutoNameTransform(name string, maxlen int, transform func(string) string) *
 				if transform != nil {
 					vs = transform(vs)
 				}
-				return resource.NewUniqueHex(vs+"-", maxlen, -1)
+				return resource.NewUniqueHex(vs+"-", maxlen, RandomHexSuffixLength)
 			},
 		},
 	}


### PR DESCRIPTION
Previously, we would attempt to add 40 characters of random hex to AutoNamed resources by default, up to the provided maxlen.

This leads to very long names, even when not necessary.  And can frequently make the amount of randomness highly dependent on the length of the provided name.

By tryng to build such large names, it also makes us very sensitive to correctly encoding the maximum length of every platform resource, which we haven't done and is very hard.

The goal of this particular source of randomness is for ensuring multiple versions of the same stack (or different stacks choosing similar resource names) deployed in the same account/region don't conflict with one another.

At 8 hex chars, or 32 bits of randomness, for N instances of the same deployed app (and not other intervention to ensure uniqueness) here are the probabilities of collision on a given resource:
N = 10 = ~.000001% (8 nines)
N = 100 = ~.0001% (6 nines)
N = 1000 = ~.01% (4 nines)
N = 10000 = ~1% (2 nines)

Related to pulumi/pulumi-fabric#316.