### PR TITLE
Support for tracing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.2.1"
 
 [[projects]]
+  name = "github.com/apache/thrift"
+  packages = ["lib/go/thrift"]
+  revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
+  version = "0.10.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/apparentlymart/go-cidr"
   packages = ["cidr"]
@@ -28,8 +34,8 @@
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/sts"]
-  revision = "6061953e33da7e141a16c70ec9535467ce7f189a"
-  version = "v1.12.24"
+  revision = "a201bf33b18ad4ab54344e4bc26b87eb6ad37b8e"
+  version = "v1.12.25"
 
 [[projects]]
   branch = "master"
@@ -48,6 +54,12 @@
   packages = ["."]
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/codahale/hdrhistogram"
+  packages = ["."]
+  revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -72,6 +84,12 @@
   name = "github.com/golang/protobuf"
   packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/empty","ptypes/struct","ptypes/timestamp"]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/grpc-ecosystem/grpc-opentracing"
+  packages = ["go/otgrpc"]
+  revision = "01f8541d537215b2867e2745a1eb85c58c7c6b81"
 
 [[projects]]
   branch = "master"
@@ -205,6 +223,12 @@
   revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
+  name = "github.com/opentracing/opentracing-go"
+  packages = [".","ext","log"]
+  revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
+  version = "v1.0.2"
+
+[[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
@@ -232,7 +256,7 @@
   branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = ["pkg/diag","pkg/diag/colors","pkg/encoding","pkg/pack","pkg/resource","pkg/resource/config","pkg/resource/plugin","pkg/resource/provider","pkg/tokens","pkg/tools","pkg/util/cmdutil","pkg/util/contract","pkg/util/fsutil","pkg/util/mapper","pkg/util/rpcutil","pkg/workspace","sdk/proto/go"]
-  revision = "d01465cf6d1cb1da0ee16cb1d485dcf1727f7636"
+  revision = "af5298f4aaf2885740635e56d576d48a89f9d557"
 
 [[projects]]
   branch = "master"
@@ -265,6 +289,18 @@
   version = "v1.1.4"
 
 [[projects]]
+  name = "github.com/uber/jaeger-client-go"
+  packages = [".","internal/spanlog","log","thrift-gen/agent","thrift-gen/jaeger","thrift-gen/sampling","thrift-gen/zipkincore","transport/zipkin","utils"]
+  revision = "3e3870040def0ebdaf65a003863fa64f5cb26139"
+  version = "v2.9.0"
+
+[[projects]]
+  name = "github.com/uber/jaeger-lib"
+  packages = ["metrics"]
+  revision = "3b2a9ad2a045881ab7a0f81d465be54c8292ee4f"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/ulikunitz/xz"
   packages = [".","internal/hash","internal/xlog","lzma"]
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
@@ -292,7 +328,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "bcc62b628abe70dd6bee1f06c4e31630209cd8d7"
+  revision = "4b45465282a4624cf39876842a017334f13b8aff"
 
 [[projects]]
   branch = "master"

--- a/pkg/tfbridge/serve.go
+++ b/pkg/tfbridge/serve.go
@@ -8,21 +8,22 @@ import (
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource/provider"
 	lumirpc "github.com/pulumi/pulumi/sdk/proto/go"
+	"golang.org/x/net/context"
 )
 
 // Serve fires up a Pulumi resource provider listening to inbound gRPC traffic,
 // and translates calls from Pulumi into actions against the provided Terraform Provider.
 func Serve(module string, info ProviderInfo) error {
 	// Create a new resource provider server and listen for and serve incoming connections.
-	return provider.Main(func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
+	return provider.Main(module, func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
 		// Set up a log redirector to capture Terraform provider logging and only pass through those that we need.
 		log.SetOutput(&LogRedirector{
 			writers: map[string]func(string) error{
-				tfTracePrefix: func(msg string) error { return host.Log(diag.Debug, msg) },
-				tfDebugPrefix: func(msg string) error { return host.Log(diag.Debug, msg) },
-				tfInfoPrefix:  func(msg string) error { return host.Log(diag.Info, msg) },
-				tfWarnPrefix:  func(msg string) error { return host.Log(diag.Warning, msg) },
-				tfErrorPrefix: func(msg string) error { return host.Log(diag.Error, msg) },
+				tfTracePrefix: func(msg string) error { return host.Log(context.TODO(), diag.Debug, msg) },
+				tfDebugPrefix: func(msg string) error { return host.Log(context.TODO(), diag.Debug, msg) },
+				tfInfoPrefix:  func(msg string) error { return host.Log(context.TODO(), diag.Info, msg) },
+				tfWarnPrefix:  func(msg string) error { return host.Log(context.TODO(), diag.Warning, msg) },
+				tfErrorPrefix: func(msg string) error { return host.Log(context.TODO(), diag.Error, msg) },
 			},
 		})
 


### PR DESCRIPTION
Extends the tracing support in https://github.com/pulumi/pulumi#541 to the Terraform bridge.

In particular, threads the gRPC context between the server side of the provider interface and the client side of the logging interface.