### PR TITLE
Rework file asset translation.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -256,7 +256,7 @@
   branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = ["pkg/diag","pkg/diag/colors","pkg/encoding","pkg/pack","pkg/resource","pkg/resource/config","pkg/resource/plugin","pkg/resource/provider","pkg/tokens","pkg/tools","pkg/util/cmdutil","pkg/util/contract","pkg/util/fsutil","pkg/util/mapper","pkg/util/rpcutil","pkg/workspace","sdk/proto/go"]
-  revision = "eec99c3ca9831940a3c54285b1b49980d24b0c2d"
+  revision = "28579eba9400231f09ca126d989b5309cf153790"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ test:
 	go tool vet -printf=false pkg/
 .PHONY: test
 
+.PHONY: format
+format:
+	find . -iname "*.go" -not -path "./vendor/*" | xargs gofmt -s -w
+
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron
 travis_cron: all

--- a/pkg/tfbridge/assets_test.go
+++ b/pkg/tfbridge/assets_test.go
@@ -30,6 +30,7 @@ func TestFileAssets(t *testing.T) {
 	text := "this is a test asset"
 	asset, err := resource.NewTextAsset(text)
 	assert.Nil(t, err)
+	asset.Hash = ""
 
 	// First, transform the asset into a file.
 	t1 := &AssetTranslation{Kind: FileAsset}
@@ -42,4 +43,77 @@ func TestFileAssets(t *testing.T) {
 	bytes, err := t2.TranslateAsset(asset)
 	assert.Nil(t, err)
 	assert.Equal(t, text, string(bytes.([]byte)))
+
+	// Next, make sure the asset is hashed and transform it into a file.
+	err = asset.EnsureHash()
+	assert.Nil(t, err)
+	file1, err := t1.TranslateAsset(asset)
+	assert.Nil(t, err)
+	assert.NotEqual(t, file.(string), file1.(string))
+	assert.True(t, strings.HasSuffix(file1.(string), asset.Hash))
+
+	// Now transform it again and ensure we get the same file.
+	file2, err := t1.TranslateAsset(asset)
+	assert.Nil(t, err)
+	assert.Equal(t, file1, file2)
+
+	// Now clear out the asset's contents and transform it to a file.
+	asset.Text = ""
+	file3, err := t1.TranslateAsset(asset)
+	assert.Nil(t, err)
+	assert.Equal(t, file1, file3)
+
+	// Now clear out the asset's hash, transform the asset to a file, and ensure it has no path.
+	asset.Hash = ""
+	file4, err := t1.TranslateAsset(asset)
+	assert.Nil(t, err)
+	assert.Equal(t, file4.(string), "")
+	assert.NotEqual(t, file1, file4)
+}
+
+func TestFileArchives(t *testing.T) {
+	text := "this is a test asset"
+	asset, err := resource.NewTextAsset(text)
+	assert.Nil(t, err)
+
+	archive, err := resource.NewAssetArchive(map[string]interface{}{"test": asset})
+	assert.Nil(t, err)
+	archive.Hash = ""
+
+	// First, transform the archive into a file.
+	t1 := &AssetTranslation{Kind: FileArchive, Format: resource.TarArchive}
+	file, err := t1.TranslateArchive(archive)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(file.(string), os.TempDir()))
+
+	// Second, transform the archive into a byte blob.
+	t2 := &AssetTranslation{Kind: BytesArchive, Format: resource.TarArchive}
+	_, err = t2.TranslateArchive(archive)
+	assert.Nil(t, err)
+
+	// Next, make sure the archive is hashed and transform it into a file.
+	err = archive.EnsureHash()
+	assert.Nil(t, err)
+	file1, err := t1.TranslateArchive(archive)
+	assert.Nil(t, err)
+	assert.NotEqual(t, file.(string), file1.(string))
+	assert.True(t, strings.HasSuffix(file1.(string), archive.Hash))
+
+	// Now transform it again and ensure we get the same file.
+	file2, err := t1.TranslateArchive(archive)
+	assert.Nil(t, err)
+	assert.Equal(t, file1, file2)
+
+	// Now clear out the archive's contents and transform it to a file.
+	archive.Assets = nil
+	file3, err := t1.TranslateArchive(archive)
+	assert.Nil(t, err)
+	assert.Equal(t, file1, file3)
+
+	// Now clear out the archive's hash, transform the archive to a file, and ensure it has no path.
+	archive.Hash = ""
+	file4, err := t1.TranslateArchive(archive)
+	assert.Nil(t, err)
+	assert.Equal(t, file4.(string), "")
+	assert.NotEqual(t, file1, file4)
 }


### PR DESCRIPTION
Note: for the purposes of this discussion, archives will be treated as
assets, as their differences are not particularly meaningful.

This commit solves one fundamental issue with file asset translation and
addresses an inefficiency.

First, translating an asset to a file currently requires that the
contents of the asset are available. This is not the case when
performing a diff, update, or delete: in the former two cases, the
contents of old assets are not available, and in the latter, the
contents of the deleted assets are not available.

Second, we currently write a new file each time we translate an asset to
a file. For archives especially, this can require a prohibitive amount
of CPU, IO, and storage resources.

These changes can both be addressed by making use of the fact that
assets are identifiable by their hash.

For assets with a hash, we can derive the translation file's name from
the hash and make a best effort to reuse an already-translated asset
with the same hash. If the asset has a hash but no contents, we can
simply return the derived file name. This has the additional benefit of
preventing false asset diffs in the case that we are diffing a resource
that has changes to non-asset properties.

For assets without a hash, we fall back to the existing strategy of
creating a new temporary file to hold the translated asset and returning
its path. If such an asset has no contents, we return the empty string,
which is guaranteed to differ from all hashed or non-empty assets.

This is the other half of the fix for pulumi/pulumi-cloud#158. Note that
these changes depend on pulumi/pulumi#548.