### PR TITLE
Add environmentCheck callback to ProviderInfo

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -17,6 +17,9 @@ type ProviderInfo struct {
 	Resources   map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
 	DataSources map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
 	Overlay     *OverlayInfo               // optional overlay information for augmented code-generation.
+
+	// Optional function to validate the provided variables and local machine environment are valid.
+	environmentCheck func(map[string]string) error
 }
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -155,6 +155,14 @@ func (p *Provider) camelPascalPulumiName(name string) (string, string) {
 // Configure configures the underlying Terraform provider with the live Pulumi variable state.
 func (p *Provider) Configure(ctx context.Context, req *lumirpc.ConfigureRequest) (*pbempty.Empty, error) {
 	p.setLoggingContext(ctx)
+
+	// Check that the provided variables and local machine environment are valid.
+	if p.info.environmentCheck != nil {
+		if err := p.info.environmentCheck(req.Variables); err != nil {
+			return nil, errors.Wrap(err, "checking environment")
+		}
+	}
+
 	// Fetch the map of tokens to values.  It will be in the form of fully qualified tokens, so
 	// we will need to translate into simply the configuration variable names.
 	vars := make(resource.PropertyMap)


### PR DESCRIPTION
This PR adds an optional `checkEnvironment` callback on the `ProviderInfo` object. If set, it will be called during `Configure` as another check required to successfully complete the RPC call.

The motivation for this new capability is to require explicit AWS credentials be present for Pulumi programs. See [PDN009](https://docs.google.com/document/d/1o8yhp3TvMvzhg_EcJ7mZcmExVbPier46w9dSqDm3_RY/edit?ts=5a0e4ba3) for more background.

The Terraform AWS provider [looks in several places](https://www.terraform.io/docs/providers/aws/) for credentials to use. If no explicit credentials are provided Terraform will fall back to using the EC2 machine's credentials.

In hosted scenarios, this would mean using the same IAM role that the PPC is running as. We shouldn't let this happen. And instead require explicit credentials be available on the PPC. Either from the Pulumi program or via environment variables on the PPC's ECS task.

Otherwise, a misconfigured PPC could end up placing AWS resources in the wrong account.

See https://github.com/pulumi/pulumi-aws/commit/878ed037a1b4102fed10b0ab5d2482a52e9c4879 for an implementation of this check in `pulumi-aws`.