### PR TITLE
Tolerate `nil` returns from `Apply`

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -333,7 +333,7 @@ func (p *Provider) Create(ctx context.Context, req *lumirpc.CreateRequest) (*lum
 	}
 
 	// Create the ID and property maps and return them.
-	props := MakeTerraformResult(newstate.Attributes, res.TFSchema, res.Schema.Fields)
+	props := MakeTerraformResult(newstate, res.TFSchema, res.Schema.Fields)
 	mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{})
 	if err != nil {
 		return nil, err
@@ -367,7 +367,7 @@ func (p *Provider) Update(ctx context.Context, req *lumirpc.UpdateRequest) (*lum
 		return nil, errors.Errorf("Error applying %v update: %v", urn, err)
 	}
 
-	props := MakeTerraformResult(newstate.Attributes, res.TFSchema, res.Schema.Fields)
+	props := MakeTerraformResult(newstate, res.TFSchema, res.Schema.Fields)
 	mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{})
 	if err != nil {
 		return nil, err
@@ -461,7 +461,7 @@ func (p *Provider) Invoke(ctx context.Context, req *lumirpc.InvokeRequest) (*lum
 			return nil, errors.Wrapf(err, "error invoking %v", tok)
 		}
 		ret, err = plugin.MarshalProperties(
-			MakeTerraformResult(invoke.Attributes, ds.TFSchema, ds.Schema.Fields),
+			MakeTerraformResult(invoke, ds.TFSchema, ds.Schema.Fields),
 			plugin.MarshalOptions{})
 		if err != nil {
 			return nil, err

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -171,13 +171,17 @@ func MakeTerraformInputsFromRPC(res *PulumiResource, m *pbstruct.Struct,
 	return MakeTerraformInputs(res, props, tfs, ps, defaults, false)
 }
 
-// MakeTerraformResult expands a Terraform-style flatmap into an expanded Pulumi resource property map.  This respects
+// MakeTerraformResult expands a Terraform state into an expanded Pulumi resource property map.  This respects
 // the property maps so that results end up with their correct Pulumi names when shipping back to the engine.
-func MakeTerraformResult(props map[string]string,
+func MakeTerraformResult(state *terraform.InstanceState,
 	tfs map[string]*schema.Schema, ps map[string]*SchemaInfo) resource.PropertyMap {
-	outs := make(map[string]interface{})
-	for _, key := range flatmap.Map(props).Keys() {
-		outs[key] = flatmap.Expand(props, key)
+	var outs map[string]interface{}
+	if state != nil {
+		outs = make(map[string]interface{})
+		attrs := state.Attributes
+		for _, key := range flatmap.Map(attrs).Keys() {
+			outs[key] = flatmap.Expand(attrs, key)
+		}
 	}
 	return MakeTerraformOutputs(outs, tfs, ps, false)
 }


### PR DESCRIPTION
At the moment, our code assumes the state object returned from
`Apply` is non-`nil`.  We have seen crashes that imply this isn't
the case and, indeed, the source code reveals that this can easily
happen:

https://github.com/hashicorp/terraform/blob/master/helper/schema/resource.go#L211

It's not immediately apparent to me the cause of that condition,
since (confusingly) it's a !d.RequiresNew that is preceded by an
if guard that d.RequiresNew; but there's plenty of mutable state
in here, and indeed L205 just above mutates the ID.  And notably,
the recordCurrentSchemaVersion function used liberally throughout
this code defends itself against nil states too:

https://github.com/hashicorp/terraform/blob/master/helper/schema/resource.go#L543

Perplexingly, pulumi/pulumi-terraform#56 happens indeterminitely.
And I'm surprised we haven't been hitting this all the time.

Nevertheless, it's clear that our handling of the state object
isn't correct, and so I'd like to submit this while concurrently
verifying that this has anything to do with the actual bug ...