### PR TITLE
Add back "-"; reduce random length to 7

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,7 +90,6 @@
   revision = "01f8541d537215b2867e2745a1eb85c58c7c6b81"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
@@ -247,7 +246,7 @@
   branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = ["pkg/diag","pkg/diag/colors","pkg/encoding","pkg/pack","pkg/resource","pkg/resource/config","pkg/resource/plugin","pkg/resource/provider","pkg/tokens","pkg/tools","pkg/util/cmdutil","pkg/util/contract","pkg/util/fsutil","pkg/util/mapper","pkg/util/rpcutil","pkg/workspace","sdk/proto/go"]
-  revision = "90c7305f555c3b1bc2ff8ba065096c56b945b128"
+  revision = "e93fe05efea6cc2dbeff391489557612e40302a0"
 
 [[projects]]
   branch = "master"

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -61,16 +61,17 @@ func TerraformToPulumiName(name string, upper bool) string {
 }
 
 // AutoName creates custom schema for a Terraform name property which is automatically populated from the
-// resource's URN name, with a random suffix and maximum length of maxlen.  This makes it easy to propagate the Pulumi
-// resource's URN name part as the Terraform name as a convenient default, while still permitting it to be overridden.
+// resource's URN name, with an 8 character random suffix ("-"+7 random chars), and maximum length of maxlen.  This
+// makes it easy to propagate the Pulumi resource's URN name part as the Terraform name as a convenient default, while
+// still permitting it to be overridden.
 func AutoName(name string, maxlen int) *SchemaInfo {
 	return AutoNameTransform(name, maxlen, nil)
 }
 
 // AutoNameTransform creates custom schema for a Terraform name property which is automatically populated from the
-// resource's URN name, with a random suffix, maximum length maxlen, and optional transformation function. This makes it
-// easy to propagate the Pulumi resource's URN name part as the Terraform name as a convenient default, while still
-// permitting it to be overridden.
+// resource's URN name, with an 8 character random suffix ("-"+7 random chars), maximum length maxlen, and optional
+// transformation function. This makes it easy to propagate the Pulumi resource's URN name part as the Terraform name
+// as a convenient default, while still permitting it to be overridden.
 func AutoNameTransform(name string, maxlen int, transform func(string) string) *SchemaInfo {
 	return &SchemaInfo{
 		Name: name,
@@ -89,7 +90,7 @@ func FromName(rand bool, maxlen int, transform func(string) string) func(res *Pu
 			vs = transform(vs)
 		}
 		if rand {
-			return resource.NewUniqueHex(vs, maxlen)
+			return resource.NewUniqueHex(vs+"-", 7, maxlen)
 		}
 		return vs, nil
 	}


### PR DESCRIPTION
This change adds back the "-" separator, and reduces the random
hash length from 8 to 7.  This increases the odds of collisions
slightly, but has the aesthetic benefit of being able to easily
see the user-specified part of the name versus the auto-generated
part of the name.  (TBH, I'm not terribly worried about collisions
these days, since most people in practice do things like prefix
with stack names, etc.  Even 7 is probably a little paranoid.)