### PR TITLE
Permit alternative types

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -38,13 +38,14 @@ type DataSourceInfo struct {
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {
-	Name    string                 // a name to override the default; "" uses the default.
-	Type    tokens.Type            // a type to override the default; "" uses the default.
-	Elem    *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
-	Fields  map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
-	Asset   *AssetTranslation      // a map of asset translation information, if this is an asset.
-	Default *DefaultInfo           // an optional default directive to be applied if a value is missing.
-	Stable  *bool                  // to override whether a property is stable or not.
+	Name     string                 // a name to override the default; "" uses the default.
+	Type     tokens.Type            // a type to override the default; "" uses the default.
+	AltTypes []tokens.Type          // alternative types that can be used instead of the override.
+	Elem     *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
+	Fields   map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
+	Asset    *AssetTranslation      // a map of asset translation information, if this is an asset.
+	Default  *DefaultInfo           // an optional default directive to be applied if a value is missing.
+	Stable   *bool                  // to override whether a property is stable or not.
 }
 
 // DocInfo contains optional overrids for finding and mapping TD docs.


### PR DESCRIPTION
This change adds the ability to create union types for Terraform inputs.
This is required because now we often flow values as configuration across
stacks -- for multi-stack linking -- and so, for instance, we won't
necessarily have a strongly typed "capability" reference to supply.  In
the future, we will have ways to look up resources by name, etc.
(see https://github.com/pulumi/pulumi/issues/83), but this probably always
needs to exist as a workaround anyway.