### PR TITLE
Support floating point numbers

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -133,6 +133,9 @@ func MakeTerraformInput(res *PulumiResource, name string,
 	case v.IsBool():
 		return v.BoolValue(), nil
 	case v.IsNumber():
+		if tfs != nil && tfs.Type == schema.TypeFloat {
+			return v.NumberValue(), nil
+		}
 		return int(v.NumberValue()), nil // convert floats to ints.
 	case v.IsString():
 		return v.StringValue(), nil
@@ -280,6 +283,8 @@ func MakeTerraformOutput(v interface{},
 		return resource.NewBoolProperty(t)
 	case int:
 		return resource.NewNumberProperty(float64(t))
+	case float64:
+		return resource.NewNumberProperty(t)
 	case string:
 		// If the string is the special unknown property sentinel, reflect back an unknown computed property.  Note that
 		// Terraform doesn't carry the types along with it, so the best we can do is give back a computed string.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -19,6 +19,7 @@ func TestTerraformInputs(t *testing.T) {
 			"nilPropertyValue":    nil,
 			"boolPropertyValue":   false,
 			"numberPropertyValue": 42,
+			"floatPropertyValue":  99.6767932,
 			"stringo":             "ognirts",
 			"arrayPropertyValue":  []interface{}{"an array"},
 			"objectPropertyValue": map[string]interface{}{
@@ -40,7 +41,8 @@ func TestTerraformInputs(t *testing.T) {
 		}),
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
-			"map_property_value": {Type: schema.TypeMap},
+			"float_property_value": {Type: schema.TypeFloat},
+			"map_property_value":   {Type: schema.TypeMap},
 			"nested_resources": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -69,6 +71,7 @@ func TestTerraformInputs(t *testing.T) {
 		"nil_property_value":    nil,
 		"bool_property_value":   false,
 		"number_property_value": 42,
+		"float_property_value":  99.6767932,
 		"string_property_value": "ognirts",
 		"array_property_value":  []interface{}{"an array"},
 		"object_property_value": map[string]interface{}{
@@ -99,6 +102,7 @@ func TestTerraformOutputs(t *testing.T) {
 			"nil_property_value":    nil,
 			"bool_property_value":   false,
 			"number_property_value": 42,
+			"float_property_value":  99.6767932,
 			"string_property_value": "ognirts",
 			"array_property_value":  []interface{}{"an array"},
 			"object_property_value": map[string]interface{}{
@@ -122,7 +126,8 @@ func TestTerraformOutputs(t *testing.T) {
 		},
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
-			"map_property_value": {Type: schema.TypeMap},
+			"float_property_value": {Type: schema.TypeFloat},
+			"map_property_value":   {Type: schema.TypeMap},
 			"nested_resources": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -149,6 +154,7 @@ func TestTerraformOutputs(t *testing.T) {
 		"nilPropertyValue":    nil,
 		"boolPropertyValue":   false,
 		"numberPropertyValue": 42,
+		"floatPropertyValue":  99.6767932,
 		"stringo":             "ognirts",
 		"arrayPropertyValue":  []interface{}{"an array"},
 		"objectPropertyValue": map[string]interface{}{


### PR DESCRIPTION
Our support for Terraform schema mapping currently assumed that
all numbers became integers.  There is, however, a schema.TypeFloat
that we should recognize and use to project numbers as floats.

This fixes pulumi/pulumi#694.