### PR TITLE
Check that worktree is clean before running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ before_install:
     - go get -v github.com/alecthomas/gometalinter
     - gometalinter --install
 install:
+    # Clone the Pulumi-wide repo so we can use its scripts.
+    - git clone git@github.com:pulumi/home ${GOPATH}/src/github.com/pulumi/home
     - make ensure
+before_script:
+    # Ensure the working tree is clean (make ensure may have updated lock files)
+    - ${GOPATH}/src/github.com/pulumi/home/scripts/check-worktree-is-clean.sh
 script:
     - make travis_${TRAVIS_EVENT_TYPE}
 notifications:


### PR DESCRIPTION
Without this, we miss cases where the lock files may need to be
updated and we encode a version like v0.9.5-dirty.