### PR TITLE
Add support for specifying peerDependencies

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -78,8 +78,9 @@ type PulumiResource struct {
 // extra files to be included from the overlays/ directory when building up packs/.  This allows augmented
 // code-generation for convenient things like helper functions, modules, and gradual typing.
 type OverlayInfo struct {
-	Files           []string                // additional files to include in the index file.
-	Modules         map[string]*OverlayInfo // extra modules to inject into the structure.
-	Dependencies    map[string]string       // NPM dependencies to add to package.json.
-	DevDependencies map[string]string       // NPM dev-dependencies to add to package.json.
+	Files            []string                // additional files to include in the index file.
+	Modules          map[string]*OverlayInfo // extra modules to inject into the structure.
+	Dependencies     map[string]string       // NPM dependencies to add to package.json.
+	DevDependencies  map[string]string       // NPM dev-dependencies to add to package.json.
+	PeerDependencies map[string]string       // NPM peer-dependencies to add to package.json.
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -932,7 +932,7 @@ func (g *generator) generateNPMPackageMetadata(outDir string, overlay *tfbridge.
 	w.Writefmtln(`    "devDependencies": {`)
 	if len(overlay.DevDependencies) > 0 {
 		var deps []string
-		for dep := range overlay.Dependencies {
+		for dep := range overlay.DevDependencies {
 			deps = append(deps, dep)
 		}
 		sort.Strings(deps)
@@ -943,6 +943,16 @@ func (g *generator) generateNPMPackageMetadata(outDir string, overlay *tfbridge.
 	w.Writefmtln(`        "typescript": "^2.5.2"`)
 	w.Writefmtln(`    },`)
 	w.Writefmtln(`    "peerDependencies": {`)
+	if len(overlay.PeerDependencies) > 0 {
+		var deps []string
+		for dep := range overlay.PeerDependencies {
+			deps = append(deps, dep)
+		}
+		sort.Strings(deps)
+		for _, dep := range deps {
+			w.Writefmtln(`        "%s": "%s",`, dep, overlay.PeerDependencies[dep])
+		}
+	}
 	w.Writefmtln(`        "pulumi": "*"`)
 	w.Writefmtln(`    }`)
 	w.Writefmtln(`}`)


### PR DESCRIPTION
This is needed to be able to specify a peer dependency on "@pulumi/cloud" in pulumi-github.

Also, fixed a copy/paste bug I noticed.