### PR TITLE
Permit overriding more package info

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -13,6 +13,11 @@ import (
 type ProviderInfo struct {
 	P           *schema.Provider           // the TF provider/schema.
 	Name        string                     // the TF provider name (e.g. terraform-provider-XXXX).
+	Description string                     // an optional descriptive overview of the package (a default will be given).
+	Keywords    []string                   // an optional list of keywords to help discovery of this package.
+	License     string                     // the license, if any, the resulting package has (default is none).
+	Homepage    string                     // the URL to the project homepage.
+	Repository  string                     // the URL to the project source code repository.
 	Config      map[string]*SchemaInfo     // a map of TF name to config schema overrides.
 	Resources   map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
 	DataSources map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.


### PR DESCRIPTION
This adds support for fields like the description, license, keywords,
repository URL, and so on, for purposes of package generation.