### PR TITLE
Add a "pulumi" section to NPM package.jsons

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -584,6 +584,11 @@ type npmPackage struct {
 	Dependencies     map[string]string `json:"dependencies,omitempty"`
 	DevDependencies  map[string]string `json:"devDependencies,omitempty"`
 	PeerDependencies map[string]string `json:"peerDependencies,omitempty"`
+	Pulumi           npmPulumiManifest `json:"pulumi,omitempty"`
+}
+
+type npmPulumiManifest struct {
+	Resource bool `json:"resource,omitempty"`
 }
 
 func (g *nodeJSGenerator) emitNPMPackageMetadata(pack *pkg) error {
@@ -610,6 +615,9 @@ func (g *nodeJSGenerator) emitNPMPackageMetadata(pack *pkg) error {
 		},
 		PeerDependencies: map[string]string{
 			"pulumi": "*",
+		},
+		Pulumi: npmPulumiManifest{
+			Resource: true,
 		},
 	}
 


### PR DESCRIPTION
This change introduces a `"pulumi"` section into our NPM package.jsons
generated for all resource providers.  For now, this has the single
boolean, `"resource": true`, which tells us that a package has a
corresponding Go plugin.  For now, there is no added extensibility, but
by the time we're done, we will also have the ability to list custom
download URLs (since release.pulumi.com isn't open to the public).