### PR TITLE
Project MaxItems==1 as nested struct instead of array

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -44,14 +44,15 @@ type DataSourceInfo struct {
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {
-	Name     string                 // a name to override the default; "" uses the default.
-	Type     tokens.Type            // a type to override the default; "" uses the default.
-	AltTypes []tokens.Type          // alternative types that can be used instead of the override.
-	Elem     *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
-	Fields   map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
-	Asset    *AssetTranslation      // a map of asset translation information, if this is an asset.
-	Default  *DefaultInfo           // an optional default directive to be applied if a value is missing.
-	Stable   *bool                  // to override whether a property is stable or not.
+	Name        string                 // a name to override the default; "" uses the default.
+	Type        tokens.Type            // a type to override the default; "" uses the default.
+	AltTypes    []tokens.Type          // alternative types that can be used instead of the override.
+	Elem        *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
+	Fields      map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
+	Asset       *AssetTranslation      // a map of asset translation information, if this is an asset.
+	Default     *DefaultInfo           // an optional default directive to be applied if a value is missing.
+	Stable      *bool                  // to override whether a property is stable or not.
+	MaxItemsOne *bool                  // to override whether this property should project as a scalar or array.
 }
 
 // DocInfo contains optional overrids for finding and mapping TD docs.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -135,7 +135,7 @@ func MakeTerraformInput(res *PulumiResource, name string,
 
 	// For TypeList or TypeSet with MaxItems==1, we will have projected as a scalar nested value, and need to wrap it
 	// into a single-element array before passing to Terraform.
-	if tfs != nil && tfs.MaxItems == 1 && (tfs.Type == schema.TypeList || tfs.Type == schema.TypeSet) {
+	if isListOrSetWithMaxItemsOne(tfs, ps) {
 		old = resource.NewArrayProperty([]resource.PropertyValue{old})
 		v = resource.NewArrayProperty([]resource.PropertyValue{v})
 	}
@@ -328,8 +328,8 @@ func MakeTerraformOutput(v interface{},
 			arr = append(arr, MakeTerraformOutput(elem, tfes, pes, assets, rawNames))
 		}
 		// For TypeList or TypeSet with MaxItems==1, we will have projected as a scalar nested value, so need to extract
-		// out the  need to wrap it into a single-element array before passing to Terraform.
-		if tfs != nil && tfs.MaxItems == 1 && (tfs.Type == schema.TypeList || tfs.Type == schema.TypeSet) {
+		// out the single element (or null).
+		if isListOrSetWithMaxItemsOne(tfs, ps) {
 			switch len(arr) {
 			case 0:
 				return resource.NewNullProperty()
@@ -573,6 +573,21 @@ func MakeTerraformDiffFromRPC(old *pbstruct.Struct, new *pbstruct.Struct,
 		}
 	}
 	return MakeTerraformDiff(oldprops, newprops, tfs, ps)
+}
+
+// isListOrSetWithMaxItemsOne returns true if the schema/info pair represents a TypeList or TypeSet which should project
+// as a scalar, else returns false.
+func isListOrSetWithMaxItemsOne(tfs *schema.Schema, info *SchemaInfo) bool {
+	if tfs == nil {
+		return false
+	}
+	if tfs.Type != schema.TypeList && tfs.Type != schema.TypeSet {
+		return false
+	}
+	if info != nil && info.MaxItemsOne != nil {
+		return *info.MaxItemsOne
+	}
+	return tfs.MaxItems == 1
 }
 
 // useRawNames returns true if raw, unmangled names should be preserved.  This is only true for Terraform maps.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -42,6 +42,10 @@ func TestTerraformInputs(t *testing.T) {
 				"someValue":      true,
 				"someOtherValue": "a value",
 			},
+			"optionalConfigOther": map[string]interface{}{
+				"someValue":      true,
+				"someOtherValue": "a value",
+			},
 		}),
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
@@ -69,11 +73,24 @@ func TestTerraformInputs(t *testing.T) {
 					},
 				},
 			},
+			"optional_config_other": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"some_value":       {Type: schema.TypeBool},
+						"some_other_value": {Type: schema.TypeString},
+					},
+				},
+			},
 		},
 		map[string]*SchemaInfo{
 			// Reverse map string_property_value to the stringo property.
 			"string_property_value": {
 				Name: "stringo",
+			},
+			"optional_config_other": {
+				Name:        "optionalConfigOther",
+				MaxItemsOne: boolPointer(true),
 			},
 		},
 		nil,   /* assets */
@@ -107,6 +124,12 @@ func TestTerraformInputs(t *testing.T) {
 			},
 		},
 		"optional_config": []interface{}{
+			map[string]interface{}{
+				"some_value":       true,
+				"some_other_value": "a value",
+			},
+		},
+		"optional_config_other": []interface{}{
 			map[string]interface{}{
 				"some_value":       true,
 				"some_other_value": "a value",
@@ -149,6 +172,12 @@ func TestTerraformOutputs(t *testing.T) {
 					"some_other_value": "a value",
 				},
 			},
+			"optional_config_other": []interface{}{
+				map[string]interface{}{
+					"some_value":       true,
+					"some_other_value": "a value",
+				},
+			},
 		},
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
@@ -176,11 +205,24 @@ func TestTerraformOutputs(t *testing.T) {
 					},
 				},
 			},
+			"optional_config_other": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"some_value":       {Type: schema.TypeBool},
+						"some_other_value": {Type: schema.TypeString},
+					},
+				},
+			},
 		},
 		map[string]*SchemaInfo{
 			// Reverse map string_property_value to the stringo property.
 			"string_property_value": {
 				Name: "stringo",
+			},
+			"optional_config_other": {
+				Name:        "optionalConfigOther",
+				MaxItemsOne: boolPointer(true),
 			},
 		},
 		nil,   /* assets */
@@ -210,6 +252,10 @@ func TestTerraformOutputs(t *testing.T) {
 			},
 		}},
 		"optionalConfig": map[string]interface{}{
+			"someValue":      true,
+			"someOtherValue": "a value",
+		},
+		"optionalConfigOther": map[string]interface{}{
 			"someValue":      true,
 			"someOtherValue": "a value",
 		},
@@ -442,4 +488,8 @@ func TestDefaults(t *testing.T) {
 		"mmm": "OLM",
 		"zzz": asset,
 	}), outputs)
+}
+
+func boolPointer(b bool) *bool {
+	return &b
 }

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -852,7 +852,13 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 
 	// If nothing was found, generate the primitive type name for this.
 	if t == "" {
-		t = tsPrimitive(sch.Type, sch.Elem, elem, sch.MaxItems == 1, out)
+		var flatten bool
+		if info != nil && info.MaxItemsOne != nil {
+			flatten = *info.MaxItemsOne
+		} else {
+			flatten = sch.MaxItems == 1
+		}
+		t = tsPrimitive(sch.Type, sch.Elem, elem, flatten, out)
 	}
 
 	// If we aren't using optional flags, we need to use TypeScript union types to permit undefined values.


### PR DESCRIPTION
This aligns better with the practical usage of TypeList with MaxItems=1 as a way to do nested structs in Terraform providers.

We do this projection and translation for both inputs and outputs.

Fixes #37.