### PR TITLE
Do not pass ":config" sufix when creating config bag

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -270,7 +270,7 @@ func (g *nodeJSGenerator) emitConfigVariables(mod *module) (string, error) {
 	}
 
 	// Create a config bag for the variables to pull from.
-	w.Writefmtln("let __config = new pulumi.Config(\"%v:config\");", g.pkg)
+	w.Writefmtln("let __config = new pulumi.Config(\"%v\");", g.pkg)
 	w.Writefmtln("")
 
 	// Emit an entry for all config variables.

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -236,7 +236,7 @@ func (g *pythonGenerator) emitConfigVariables(mod *module) (string, error) {
 	defer contract.IgnoreClose(w)
 
 	// Create a config bag for the variables to pull from.
-	w.Writefmtln("__config__ = pulumi.Config('%s:config')", g.pkg)
+	w.Writefmtln("__config__ = pulumi.Config('%s')", g.pkg)
 	w.Writefmtln("")
 
 	// Emit an entry for all config variables.


### PR DESCRIPTION
In pulumi/pulumi@d58bc719c4cf06fc2fcbdc7f5265a7bf2a05dce3 we stopped requiring the `:config` tag when newing up a config object. While the old form is still supported, it issues a warning.

This updates tfgen to generate a vars file on the new plan. 