### PR TITLE
Add a way to transform TypeMap keys

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -44,15 +44,16 @@ type DataSourceInfo struct {
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {
-	Name        string                 // a name to override the default; "" uses the default.
-	Type        tokens.Type            // a type to override the default; "" uses the default.
-	AltTypes    []tokens.Type          // alternative types that can be used instead of the override.
-	Elem        *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
-	Fields      map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
-	Asset       *AssetTranslation      // a map of asset translation information, if this is an asset.
-	Default     *DefaultInfo           // an optional default directive to be applied if a value is missing.
-	Stable      *bool                  // to override whether a property is stable or not.
-	MaxItemsOne *bool                  // to override whether this property should project as a scalar or array.
+	Name              string                 // a name to override the default; "" uses the default.
+	Type              tokens.Type            // a type to override the default; "" uses the default.
+	AltTypes          []tokens.Type          // alternative types that can be used instead of the override.
+	Elem              *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
+	Fields            map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
+	Asset             *AssetTranslation      // a map of asset translation information, if this is an asset.
+	Default           *DefaultInfo           // an optional default directive to be applied if a value is missing.
+	Stable            *bool                  // to override whether a property is stable or not.
+	MaxItemsOne       *bool                  // to override whether this property should project as a scalar or array.
+	MangleTypeMapKeys *bool                  // to override whether TypeMap keys should be mangled.
 }
 
 // DocInfo contains optional overrids for finding and mapping TD docs.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -229,7 +229,7 @@ func MakeTerraformInput(res *PulumiResource, name string,
 			oldObject = old.ObjectValue()
 		}
 		return MakeTerraformInputs(res, oldObject, v.ObjectValue(),
-			tfflds, psflds, assets, defaults, rawNames || useRawNames(tfs))
+			tfflds, psflds, assets, defaults, rawNames || useRawNames(tfs, ps))
 	case v.IsComputed() || v.IsOutput():
 		// If any variables are unknown, we need to mark them in the inputs so the config map treats it right.  This
 		// requires the use of the special UnknownVariableValue sentinel in Terraform, which is how it internally stores
@@ -351,7 +351,7 @@ func MakeTerraformOutput(v interface{},
 		if ps != nil {
 			psflds = ps.Fields
 		}
-		obj := MakeTerraformOutputs(t, tfflds, psflds, assets, rawNames || useRawNames(tfs))
+		obj := MakeTerraformOutputs(t, tfflds, psflds, assets, rawNames || useRawNames(tfs, ps))
 		return resource.NewObjectProperty(obj)
 	default:
 		contract.Failf("Unexpected TF output property value: %v", v)
@@ -591,8 +591,14 @@ func isListOrSetWithMaxItemsOne(tfs *schema.Schema, info *SchemaInfo) bool {
 }
 
 // useRawNames returns true if raw, unmangled names should be preserved.  This is only true for Terraform maps.
-func useRawNames(tfs *schema.Schema) bool {
-	return tfs != nil && tfs.Type == schema.TypeMap
+func useRawNames(tfs *schema.Schema, info *SchemaInfo) bool {
+	if tfs != nil && tfs.Type == schema.TypeMap {
+		if info != nil && info.MangleTypeMapKeys != nil {
+			return !*info.MangleTypeMapKeys
+		}
+		return true
+	}
+	return false
 }
 
 // getInfoFromTerraformName does a map lookup to find the Pulumi name and schema info, if any.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -33,6 +33,13 @@ func TestTerraformInputs(t *testing.T) {
 					"nestedPropertyA": true,
 				},
 			},
+			"mapPropertyValueMangled": map[string]interface{}{
+				"propertyA": "a",
+				"propertyB": true,
+				"propertyC": map[string]interface{}{
+					"nestedPropertyA": true,
+				},
+			},
 			"nestedResources": []map[string]interface{}{{
 				"configuration": map[string]interface{}{
 					"configurationValue": true,
@@ -49,8 +56,9 @@ func TestTerraformInputs(t *testing.T) {
 		}),
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
-			"float_property_value": {Type: schema.TypeFloat},
-			"map_property_value":   {Type: schema.TypeMap},
+			"float_property_value":       {Type: schema.TypeFloat},
+			"map_property_value":         {Type: schema.TypeMap},
+			"map_property_value_mangled": {Type: schema.TypeMap},
 			"nested_resource": {
 				Type:     schema.TypeList,
 				MaxItems: 2,
@@ -92,6 +100,10 @@ func TestTerraformInputs(t *testing.T) {
 				Name:        "optionalConfigOther",
 				MaxItemsOne: boolPointer(true),
 			},
+			"map_property_value_mangled": {
+				Name:              "mapPropertyValueMangled",
+				MangleTypeMapKeys: boolPointer(true),
+			},
 		},
 		nil,   /* assets */
 		false, /*defaults*/
@@ -114,6 +126,13 @@ func TestTerraformInputs(t *testing.T) {
 			"propertyB": true,
 			"propertyC": map[string]interface{}{
 				"nestedPropertyA": true,
+			},
+		},
+		"map_property_value_mangled": map[string]interface{}{
+			"property_a": "a",
+			"property_b": true,
+			"property_c": map[string]interface{}{
+				"nested_property_a": true,
 			},
 		},
 		"nested_resource": []interface{}{
@@ -159,6 +178,13 @@ func TestTerraformOutputs(t *testing.T) {
 					"nestedPropertyA": true,
 				},
 			},
+			"map_property_value_mangled": map[string]interface{}{
+				"property_a": "a",
+				"property_b": true,
+				"property_c": map[string]interface{}{
+					"nested_property_a": true,
+				},
+			},
 			"nested_resource": []interface{}{
 				map[string]interface{}{
 					"configuration": map[string]interface{}{
@@ -181,8 +207,9 @@ func TestTerraformOutputs(t *testing.T) {
 		},
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
-			"float_property_value": {Type: schema.TypeFloat},
-			"map_property_value":   {Type: schema.TypeMap},
+			"float_property_value":       {Type: schema.TypeFloat},
+			"map_property_value":         {Type: schema.TypeMap},
+			"map_property_value_mangled": {Type: schema.TypeMap},
 			"nested_resource": {
 				Type:     schema.TypeList,
 				MaxItems: 2,
@@ -224,6 +251,10 @@ func TestTerraformOutputs(t *testing.T) {
 				Name:        "optionalConfigOther",
 				MaxItemsOne: boolPointer(true),
 			},
+			"map_property_value_mangled": {
+				Name:              "mapPropertyValueMangled",
+				MangleTypeMapKeys: boolPointer(true),
+			},
 		},
 		nil,   /* assets */
 		false, /*useRawNames*/
@@ -240,6 +271,13 @@ func TestTerraformOutputs(t *testing.T) {
 			"propertyB": true,
 		},
 		"mapPropertyValue": map[string]interface{}{
+			"propertyA": "a",
+			"propertyB": true,
+			"propertyC": map[string]interface{}{
+				"nestedPropertyA": true,
+			},
+		},
+		"mapPropertyValueMangled": map[string]interface{}{
 			"propertyA": "a",
 			"propertyB": true,
 			"propertyC": map[string]interface{}{


### PR DESCRIPTION
There are cases where we'd like to transform TypeMap keys, like in pulumi-github. This change adds a `MangleTypeMaps` option for doing so.

Fixes #111