### PR TITLE
Implement Read; generate get

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "a3a6101e792defeaa3cb3db13aeaa850b0d8dbe5"
+  revision = "62042cd3edd1d60787b765dcc2e863df6d0eb667"
 
 [[projects]]
   branch = "master"
@@ -546,6 +546,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a8a728112adf136ab61269d8b125fe2bfb9fa9555ac310c83204c9d73c18ff78"
+  inputs-digest = "9a9693a259dff2ee13b1985ebbfeef97b1411665a664d01535940e7ab796aa6e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[constraint]]
   name = "github.com/pulumi/pulumi"
-  revision = "a3a6101e792defeaa3cb3db13aeaa850b0d8dbe5"
+  revision = "62042cd3edd1d60787b765dcc2e863df6d0eb667"
 
 # Redirect all Terraform references to our fork.
 [[override]]


### PR DESCRIPTION
This change does two basic things.

First, it implements the new Read RPC method on the resource provider
interface.  This simply calls through to the underlying Terraform
provider's Refresh function, marshaling state to and fro as usual.

Second, it generates a static `get` function on all resource types:

    public static get(name: string, id: Input<ID>, state?: RState): R;

This function takes a name, for purposes of URN creation, a resource
ID to use in the lookup, and an optional RState object for further
lookup filtering.  It uses the Read method to lookup and populate the
complete resource state and returns an instance of the enclosing
resource type R.

Note that RState is not known a priori and in fact just contains all
possible properties the given resource could have.  Many resources can
be loaded just given their ID, but certain other complex resources
cannot; the requirements here are highly resource dependent.