### PR TITLE
Update to a newer pulumi/pulumi.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -367,7 +367,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
+  revision = "4f3d2366064de9a0098b959a05ba1aa1d95c7e0b"
 
 [[projects]]
   branch = "master"
@@ -548,6 +548,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "41c662d03e25c221480daa1b07c81ab809ab772b3ed5f4cc5b1a4b10e1798d27"
+  inputs-digest = "c2f3bc43a709d03ac45c060ba7041e7fb197012e83d76e2a368943d75e88ff38"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[constraint]]
   name = "github.com/pulumi/pulumi"
-  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
+  revision = "4f3d2366064de9a0098b959a05ba1aa1d95c7e0b"
 
 # Redirect all Terraform references to our fork.
 [[override]]

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -56,11 +56,6 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 				return err
 			}
 
-			// If we succeeded at generate, but there were errors, exit unsuccessfully.
-			if !cmdutil.Diag().Success() {
-				os.Exit(-2)
-			}
-
 			return nil
 		}),
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This is required in order to enable integration test tracing in
dependent repositories.