### PR TITLE
Add a PreConfigure callback

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -4,6 +4,7 @@ package tfbridge
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
@@ -24,6 +25,8 @@ type ProviderInfo struct {
 	Overlay     *OverlayInfo               // optional overlay information for augmented code-generation.
 	JavaScript  *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
 	Python      *PythonInfo                // optional overlay information for augmented Python code-generation.
+
+	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
@@ -101,3 +104,6 @@ type JavaScriptInfo struct {
 type PythonInfo struct {
 	Requires map[string]string // Pip install_requires information.
 }
+
+// PreConfigureCallback is a function to invoke prior to calling the TF provider Configure
+type PreConfigureCallback func(vars resource.PropertyMap, config *terraform.ResourceConfig) error

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -211,6 +211,12 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 		return nil, errors.Wrap(err, "could not marshal config state")
 	}
 
+	if p.info.PreConfigureCallback != nil {
+		if err = p.info.PreConfigureCallback(vars, config); err != nil {
+			return nil, err
+		}
+	}
+
 	// Perform validation of the config state so we can offer nice errors.
 	warns, errs := p.tf.Validate(config)
 	for _, warn := range warns {


### PR DESCRIPTION
This allows providers to pre-validate configuration, and in particualr credentials, before handing off to the TF provider.

Part of addressing pulumi/pulumi-aws/issues/192 and pulumi/home/issues/241.