### PR TITLE
Use TF provider name instead of Pulumi package name name conversion

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -164,7 +164,7 @@ func (p *Provider) initResourceMaps() {
 // camelPascalPulumiName returns the camel and pascal cased name for a given terraform name.
 func (p *Provider) camelPascalPulumiName(name string) (string, string) {
 	// Strip off the module prefix (e.g., "aws_") and then return the camel- and Pascal-cased names.
-	prefix := p.module + "_" // all resources will have this prefix.
+	prefix := p.info.Name + "_" // all resources will have this prefix.
 	contract.Assertf(strings.HasPrefix(name, prefix),
 		"Expected all Terraform resources in this module to have a '%v' prefix", prefix)
 	name = name[len(prefix):]


### PR DESCRIPTION
Fixes the issue preventing updating `pulumi-azure` to the latest `pulumi-terraform` - as seen at https://travis-ci.com/pulumi/pulumi-azure/builds/74581052?utm_source=github_status&utm_medium=notification.