### PR TITLE
Don't emit presence checks for Python types

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -348,14 +348,7 @@ func (g *pythonGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType
 		// Check that required arguments are present.  Also check that types are as expected.
 		pname := pyName(prop.name)
 		ptype := pyType(prop)
-		if !prop.optional() {
-			w.Writefmtln("        if not %s:", pname)
-			w.Writefmtln("            raise TypeError('Missing required argument %s')", pname)
-			w.Writefmt("        elif ")
-		} else {
-			w.Writefmt("        if %s and ", pname)
-		}
-		w.Writefmtln("not isinstance(%s, %s):", pname, ptype)
+		w.Writefmt("        if %s and not isinstance(%s, %s):", pname, pname, ptype)
 		w.Writefmtln("            raise TypeError('Expected argument %s to be a %s')", pname, ptype)
 
 		// Now perform the assignment, and follow it with a """ doc comment if there was one found.
@@ -518,7 +511,7 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 	if fun.retst != nil {
 		w.Writefmtln("    return %s(", fun.retst.name)
 		for i, ret := range fun.rets {
-			w.Writefmt("        %s=__ret__['%s']", pyName(ret.name), ret.name)
+			w.Writefmt("        %s=__ret__.get('%s')", pyName(ret.name), ret.name)
 			if i == len(fun.rets)-1 {
 				w.Writefmtln(")")
 			} else {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform/issues/160.

Terraform can (and does) omit values for `Computed` and `Optional` fields. I haven't seen any cases where this occurs for resources, but there are several cases in `aws` which this occurs for datasources.

Per Luke (https://github.com/pulumi/pulumi-terraform/issues/160#issuecomment-395296635), I think it's best that we don't emit presence checks. We don't do this for JavaScript and not doing so allows the Python provider to interact with data sources in the same manner as JavaScript and Terraform itself (that is, that no checks occur and you get an exception if you try to use a property that is not set).