### PR TITLE
Project assets properly as 'Inputs' when appropriate.

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -882,6 +882,10 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 			}
 		} else if info.Asset != nil {
 			t = "pulumi.asset." + info.Asset.Type()
+
+			if !out {
+				t = fmt.Sprintf("pulumi.Input<%s>", t)
+			}
 		}
 
 		elem = info.Elem


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/235

Tagging @lukehoban .  I have validated that this produces the right result when run in pulumi-aws.