### PR TITLE
Don't put fixed version in generated files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -372,7 +372,6 @@
     "pkg/resource/provider",
     "pkg/tokens",
     "pkg/tools",
-    "pkg/util/buildutil",
     "pkg/util/cmdutil",
     "pkg/util/contract",
     "pkg/util/fsutil",
@@ -562,6 +561,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "68749e8f70c4e7ab7dda028af8a8baed391ebc8355fa66e8d0564df77e3c56e3"
+  inputs-digest = "441b92a5b3e1ca5b379db4de620d2c0a25cdef4375a71d8a61f02d390744370c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -638,12 +638,16 @@ func (g *nodeJSGenerator) emitNPMPackageMetadata(pack *pkg) error {
 	// Create info that will get serialized into an NPM package.json.
 	npminfo := npmPackage{
 		Name:        fmt.Sprintf("@pulumi/%s", pack.name),
-		Version:     pack.version,
+		Version:     "${VERSION}",
 		Description: g.info.Description,
 		Keywords:    g.info.Keywords,
 		Homepage:    g.info.Homepage,
 		Repository:  g.info.Repository,
 		License:     g.info.License,
+		// Ideally, this `scripts` section would include an install script that installs the provider, however, doing
+		// so causes problems when we try to restore package dependencies, since we must do an install for that. So
+		// we have another process that adds the install script when generating the package.json that we actually
+		// publish.
 		Scripts: map[string]string{
 			"build": "tsc",
 		},

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/tools"
-	"github.com/pulumi/pulumi/pkg/util/buildutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
@@ -556,19 +555,13 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	w.Writefmtln("class InstallPluginCommand(install):")
 	w.Writefmtln("    def run(self):")
 	w.Writefmtln("        install.run(self)")
-	w.Writefmtln("        check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '%s'])",
-		pack.name, pack.version)
+	w.Writefmtln("        check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}'])",
+		pack.name)
 	w.Writefmtln("")
-
-	// Mangle the version (which is a semver, by convention) so it is PEP440 compatable
-	version, err := buildutil.PyPiVersionFromNpmVersion(pack.version)
-	if err != nil {
-		return err
-	}
 
 	// Finally, the actual setup part.
 	w.Writefmtln("setup(name='%s',", pyPack(pack.name))
-	w.Writefmtln("      version='%s',", version)
+	w.Writefmtln("      version='${VERSION}',")
 	if g.info.Description != "" {
 		w.Writefmtln("      description='%s',", g.info.Description)
 	}


### PR DESCRIPTION
Instead of embedding the actual version in our generated package.json
and setup.py files, just put in a replacement string, which our
providers will replace with an actual version at build time. This
allows us to keep the working tree clean.