### PR TITLE
Fix camel case to snake case converter implementation

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/tools"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
@@ -360,7 +361,7 @@ func (g *pythonGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType
 
 func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (string, error) {
 	// Create a resource file for this resource's module.
-	name := pyName(lowerFirst(res.name))
+	name := pyName(res.name)
 	w, err := g.openWriter(mod, name+".py", true)
 	if err != nil {
 		return "", err
@@ -667,25 +668,112 @@ func pyPack(s string) string {
 }
 
 // pyName turns a variable or function name, normally using camelCase, to an underscore_case name.
-func pyName(s string) string {
-	var result string
+func pyName(name string) string {
+	// This method is a state machine with four states:
+	//   stateFirst - the initial state.
+	//   stateUpper - The last character we saw was an uppercase letter and the character before it
+	//                was either a number or a lowercase letter.
+	//   stateAcronym - The last character we saw was an uppercase letter and the character before it
+	//                  was an uppercase letter.
+	//   stateLowerOrNumber - The last character we saw was a letter or a number.
+	//
+	// The following are the state transitions of this state machine:
+	//   stateFirst -> (uppercase letter) -> stateUpper
+	//   stateFirst -> (lowercase letter or number) -> stateLowerOrNumber
+	//      Append the lower-case form of the character to currentComponent.
+	//
+	//   stateUpper -> (uppercase letter) -> stateAcronym
+	//   stateUpper -> (lowercase letter or number) -> stateLowerOrNumber
+	//      Append the lower-case form of the character to currentComponent.
+	//
+	//   stateAcronym -> (uppercase letter) -> stateAcronym
+	//		Append the lower-case form of the character to currentComponent.
+	//   stateAcronym -> (lowercase letter or number) -> stateLowerOrNumber
+	//      Take all but the last character in currentComponent, turn that into
+	//      a string, and append that to components. Set currentComponent to the
+	//      last two characters seen.
+	//
+	//   stateLowerOrNumber -> (uppercase letter) -> stateUpper
+	//      Take all characters in currentComponent, turn that into a string,
+	//      and append that to components. Set currentComponent to the last
+	//      character seen.
+	//	 stateLowerOrNumber -> (lowercase letter) -> stateLowerOrNumber
+	//      Append the character to currentComponent.
+	//
+	// The Go libraries that convert camelCase to snake_case deviate subtly from
+	// the semantics we're going for in this method, namely that they separate
+	// numbers and lowercase letters. We don't want this (we want e.g. Sha256Hash to
+	// be converted as sha256_hash).
+	//
+	// As for why this is a state machine, the libraries that do this all pretty much use
+	// either regular expressions or state machines, which I suppose are ultimately the same thing.
+	const (
+		stateFirst = iota
+		stateUpper
+		stateAcronym
+		stateLowerOrNumber
+	)
 
-	// Eat any leading __s.
-	i := 0
-	for ; i < len(s) && s[i] == '_'; i++ {
-		result += "_"
-	}
+	var components []string     // The components that will be joined together with underscores
+	var currentComponent []rune // The characters composing the current component being built
+	state := stateFirst
+	for _, char := range name {
+		switch state {
+		case stateFirst:
+			if unicode.IsUpper(char) {
+				// stateFirst -> stateUpper
+				state = stateUpper
+				currentComponent = append(currentComponent, unicode.ToLower(char))
+				continue
+			}
 
-	// Now do the substitutions.
-	for ; i < len(s); i++ {
-		c := s[i]
-		contract.Assertf(c != '_', "Unexpected underscore %d in pre-Pythonified name %s", i, s)
-		if unicode.IsUpper(rune(c)) {
-			result += "_" + string(unicode.ToLower(rune(c)))
-		} else {
-			result += string(c)
+			// stateFirst -> stateLowerOrNumber
+			state = stateLowerOrNumber
+			currentComponent = append(currentComponent, char)
+			continue
+
+		case stateUpper:
+			if unicode.IsUpper(char) {
+				// stateUpper -> stateAcronym
+				state = stateAcronym
+				currentComponent = append(currentComponent, unicode.ToLower(char))
+				continue
+			}
+
+			// stateUpper -> stateLowerOrNumber
+			state = stateLowerOrNumber
+			currentComponent = append(currentComponent, char)
+			continue
+
+		case stateAcronym:
+			if unicode.IsUpper(char) {
+				// stateAcronym -> stateAcronym
+				currentComponent = append(currentComponent, unicode.ToLower(char))
+				continue
+			}
+
+			// stateAcronym -> stateLowerOrNumber
+			last, rest := currentComponent[len(currentComponent)-1], currentComponent[:len(currentComponent)-1]
+			components = append(components, string(rest))
+			currentComponent = []rune{last, char}
+			state = stateLowerOrNumber
+			continue
+
+		case stateLowerOrNumber:
+			if unicode.IsUpper(char) {
+				// stateLowerOrNumber -> stateUpper
+				components = append(components, string(currentComponent))
+				currentComponent = []rune{unicode.ToLower(char)}
+				state = stateUpper
+				continue
+			}
+
+			// stateLowerOrNumber -> stateLowerOrNumber
+			currentComponent = append(currentComponent, char)
+			continue
 		}
 	}
 
-	return result
+	components = append(components, string(currentComponent))
+	return strings.Join(components, "_")
 }

--- a/pkg/tfgen/generate_python_test.go
+++ b/pkg/tfgen/generate_python_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests that we convert from CamelCase resource names to pythonic
+// snake_case correctly.
+func TestPyName(t *testing.T) {
+	tests := [][]string{
+		{"IAMPolicy", "iam_policy"},
+		{"SubscriptionIAMBinding", "subscription_iam_binding"},
+		{"Route", "route"},
+		{"InstanceGroup", "instance_group"},
+		{"Ipv4Thingy", "ipv4_thingy"},
+		{"Sha256Hash", "sha256_hash"},
+		{"foo4Bar", "foo4_bar"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase[0], func(tt *testing.T) {
+			out := pyName(testCase[0])
+			assert.Equal(tt, testCase[1], out)
+		})
+	}
+}

--- a/pkg/tfgen/generate_python_test.go
+++ b/pkg/tfgen/generate_python_test.go
@@ -30,6 +30,8 @@ func TestPyName(t *testing.T) {
 		{"InstanceGroup", "instance_group"},
 		{"Ipv4Thingy", "ipv4_thingy"},
 		{"Sha256Hash", "sha256_hash"},
+		{"SHA256Hash", "sha256_hash"},
+		{"LongACME7Name", "long_acme7_name"},
 		{"foo4Bar", "foo4_bar"},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform/issues/173.

Camel case to snake case conversion is tricky. I tried a couple different Go libraries that claim to do this, and although they all "work", each one has a slightly different idea of how numbers interact with camel case to snake case conversion that resulted in less-than-optimal resource names. In particular, most of the libraries I tried considered numbers to be separate from lower case letters, so things such as `Sha256Hash` got turned into `sha_256_hash`, which resulted in a lot of breaking name changes in the `pulumi-gcp` provider.

In the hopes of being absolutely sure what sort of names that tfgen produces, and being unable to find a library that does exactly what we want, this PR has a camel case to snake case implementation. This implementation considers digits to be identical to lowercase numbers, so that `Sha256Hash` is treated as `sha256_hash`, which matches the implementation today while still fixing #173 .

The implementation itself is a straight-up state machine. Most of the libraries I looked at take some sort of state machine approach, using either regexes or a hand-coded approach. I chose the latter here because I can wrap my head around it a little easier, as much as I love writing insanely complex regular expressions.