### PR TITLE
Respect existing `id` property from data source if present

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -621,9 +621,11 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 			return nil, errors.Wrapf(err, "invoking %s", tok)
 		}
 
-		// Add the special "id" attribute which isn't listed in the schema
+		// Add the special "id" attribute if it wasn't listed in the schema
 		props := MakeTerraformResult(invoke, ds.TFSchema, ds.Schema.Fields)
-		props["id"] = resource.NewStringProperty(invoke.ID)
+		if _, has := props["id"]; !has {
+			props["id"] = resource.NewStringProperty(invoke.ID)
+		}
 
 		ret, err = plugin.MarshalProperties(
 			props,

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -684,15 +684,18 @@ func (g *generator) gatherDataSource(rawname string,
 		}
 	}
 
-	// Add the special "id" attribute. This isn't exposed via terraform schema, so we make one up.
-	sch := &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
+	// If the data source's schema doesn't expose an id property, make one up since we'd like to expose it for data
+	// sources.
+	if _, has := args["id"]; !has {
+		sch := &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		}
+		cust := &tfbridge.SchemaInfo{}
+		rawdoc := "id is the provider-assigned unique ID for this managed resource."
+		fun.rets = append(fun.rets,
+			propertyVariable("id", sch, cust, "", rawdoc, "", true /*out*/))
 	}
-	cust := &tfbridge.SchemaInfo{}
-	rawdoc := "id is the provider-assigned unique ID for this managed resource."
-	fun.rets = append(fun.rets,
-		propertyVariable("id", sch, cust, "", rawdoc, "", true /*out*/))
 
 	// Produce the args/return types, if needed.
 	if len(fun.args) > 0 {


### PR DESCRIPTION
Some data sources already have an `id` property exposed from their
schema. For example, `data_source_aws_nat_gateway` in the AWS
provider. In that case, we don't need to add one ourselves.