### PR TITLE
Don't emit Removed fields in sub-structure properties

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -127,7 +127,7 @@ func (p *Provider) initResourceMaps() {
 
 		p.resources[tok] = Resource{
 			TF:       res,
-			TFSchema: p.tf.ResourcesMap[res.Name].Schema,
+			TFSchema: CleanTerraformSchema(p.tf.ResourcesMap[res.Name].Schema),
 			Schema:   schema,
 		}
 	}
@@ -155,7 +155,7 @@ func (p *Provider) initResourceMaps() {
 
 		p.dataSources[tok] = DataSource{
 			TF:       ds,
-			TFSchema: p.tf.DataSourcesMap[ds.Name].Schema,
+			TFSchema: CleanTerraformSchema(p.tf.DataSourcesMap[ds.Name].Schema),
 			Schema:   schema,
 		}
 	}


### PR DESCRIPTION
tfbridge/gen checked the terraform schema "Removed" property for top
level fields in resources, but it wasn't checked for fields of
sub-structures (such as "networks" on an openstack compute_instance_v2
resource).

This adds a method to do a recursive clean on resources to remove all
"Removed" attributes. The method is used by both tfbridge and tfgen when
reading from the terraform providers ResourcesMap and DataSourcesMap.