### PR TITLE
Allow 'computed' assets

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -339,14 +339,13 @@ func MakeTerraformOutput(v interface{},
 
 		// we might not have the asset value if this was something computed. in that
 		// case just return an appropriate sentinel indicating that was the case.
-		contract.Assert(v != nil)
-		contract.Assert(reflect.ValueOf(v).Kind() == reflect.String)
 
-		t := v.(string)
+		t, ok := v.(string)
+		contract.Assert(ok)
 		contract.Assert(t == config.UnknownVariableValue)
 
-		elem := resource.Computed{Element: resource.NewStringProperty("")}
-		return resource.NewComputedProperty(elem)
+		return resource.NewComputedProperty(
+			resource.Computed{Element: resource.NewStringProperty("")})
 	}
 
 	if v == nil {
@@ -368,8 +367,8 @@ func MakeTerraformOutput(v interface{},
 		// Terraform doesn't carry the types along with it, so the best we can do is give back a computed string.
 		t := val.String()
 		if t == config.UnknownVariableValue {
-			elem := resource.Computed{Element: resource.NewStringProperty("")}
-			return resource.NewComputedProperty(elem)
+			return resource.NewComputedProperty(
+				resource.Computed{Element: resource.NewStringProperty("")})
 		}
 		// Else it's just a string.
 		return resource.NewStringProperty(t)

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -329,11 +329,24 @@ func MakeTerraformOutputs(outs map[string]interface{},
 // MakeTerraformOutput takes a single Terraform property and returns the Pulumi equivalent.
 func MakeTerraformOutput(v interface{},
 	tfs *schema.Schema, ps *SchemaInfo, assets AssetTable, rawNames bool) resource.PropertyValue {
+
 	if assets != nil && ps != nil && ps.Asset != nil {
-		asset, has := assets[ps]
-		contract.Assertf(has, "expected asset value for Pulumi schema info")
-		contract.Assert(asset.IsAsset() || asset.IsArchive())
-		return asset
+		if asset, has := assets[ps]; has {
+			// if we have the value, it better actually be an asset or an archive.
+			contract.Assert(asset.IsAsset() || asset.IsArchive())
+			return asset
+		}
+
+		// we might not have the asset value if this was something computed. in that
+		// case just return an appropriate sentinel indicating that was the case.
+		contract.Assert(v != nil)
+		contract.Assert(reflect.ValueOf(v).Kind() == reflect.String)
+
+		t := v.(string)
+		contract.Assert(t == config.UnknownVariableValue)
+
+		elem := resource.Computed{Element: resource.NewStringProperty("")}
+		return resource.NewComputedProperty(elem)
 	}
 
 	if v == nil {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -530,6 +530,47 @@ func TestDefaults(t *testing.T) {
 	}), outputs)
 }
 
+func TestComputedAsset(t *testing.T) {
+
+	assets := make(AssetTable)
+	tfs := map[string]*schema.Schema{
+		"zzz": {Type: schema.TypeString},
+	}
+	ps := map[string]*SchemaInfo{
+		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
+	}
+	olds := resource.PropertyMap{}
+	props := resource.PropertyMap{
+		"zzz": resource.NewStringProperty(config.UnknownVariableValue),
+	}
+	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
+	assert.NoError(t, err)
+	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false)
+	assert.Equal(t, resource.PropertyMap{
+		"zzz": resource.PropertyValue{V: resource.Computed{Element: resource.PropertyValue{V: ""}}},
+	}, outputs)
+}
+
+func TestInvalidAsset(t *testing.T) {
+
+	assets := make(AssetTable)
+	tfs := map[string]*schema.Schema{
+		"zzz": {Type: schema.TypeString},
+	}
+	ps := map[string]*SchemaInfo{
+		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
+	}
+	olds := resource.PropertyMap{}
+	props := resource.PropertyMap{
+		"zzz": resource.NewStringProperty("invalid"),
+	}
+	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
+	assert.NoError(t, err)
+	assert.Panics(t, func() {
+		MakeTerraformOutputs(inputs, tfs, ps, assets, false)
+	})
+}
+
 func boolPointer(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform/issues/191

Our current terraform provider assets that something typed to be an asset must actually be an asset.  However, during preview, we may have an Output<Asset|Archive>.  These will remote to the terraform provider as an 'unknown variable value'.  

This change simply updates the provider to expect that that can happen and to handle it properly (by mapping it to 'computed' value).  