### PR TITLE
Update pulumi/pulumi.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,6 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -134,7 +133,8 @@
     "ptypes/struct",
     "ptypes/timestamp"
   ]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -385,7 +385,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "5dd2f10993f2e7b8350b4b795fb9d605dd53f94a"
+  revision = "61324d554059ea96a89460d0ede30eaba4368fb3"
 
 [[projects]]
   branch = "master"

--- a/pkg/tfbridge/assets_test.go
+++ b/pkg/tfbridge/assets_test.go
@@ -74,13 +74,6 @@ func TestFileAssets(t *testing.T) {
 	file3, err := t1.TranslateAsset(asset)
 	assert.Nil(t, err)
 	assert.Equal(t, file1, file3)
-
-	// Now clear out the asset's hash, transform the asset to a file, and ensure it has no path.
-	asset.Hash = ""
-	file4, err := t1.TranslateAsset(asset)
-	assert.Nil(t, err)
-	assert.Equal(t, file4.(string), "")
-	assert.NotEqual(t, file1, file4)
 }
 
 func TestFileArchives(t *testing.T) {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -649,3 +649,8 @@ func (p *Provider) GetPluginInfo(ctx context.Context, req *pbempty.Empty) (*pulu
 		Version: p.version,
 	}, nil
 }
+
+// Cancel requests that the provider cancel all ongoing RPCs. For TF, this is a no-op.
+func (p *Provider) Cancel(ctx context.Context, req *pbempty.Empty) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}


### PR DESCRIPTION
This requires adding a new method to the provider server, Cancel, which
requests that the provider abort any ongoing resource operations. We
currently implement this as a no-op. It's not clear that we can
reasonably do any better given TF's provider API, which has no
first-class affordances for cancellation.