### PR TITLE
Improvements to Input/Output generation

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -670,7 +670,8 @@ func (g *generator) gatherDataSource(rawname string,
 		// Remember detailed information for every input arg (we will use it below).
 		docURL := fmt.Sprintf("%s#%s", parsedDocs.URL, arg)
 		if input(args[arg]) {
-			// Note: Although these are arguments, we pass `out` as true to ensure that the arguments do not get wrapped in `pulumi.Input`.
+			// Note: Although these are arguments, we pass `out` as true to ensure that the arguments do not get wrapped
+			// in `pulumi.Input`.
 			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", docURL, true /*out*/)
 			fun.args = append(fun.args, argvar)
 			if !argvar.optional() {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -670,9 +670,7 @@ func (g *generator) gatherDataSource(rawname string,
 		// Remember detailed information for every input arg (we will use it below).
 		docURL := fmt.Sprintf("%s#%s", parsedDocs.URL, arg)
 		if input(args[arg]) {
-			// Note: Although these are arguments, we pass `out` as true to ensure that the arguments do not get wrapped
-			// in `pulumi.Input`.
-			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", docURL, true /*out*/)
+			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", docURL, false /*out*/)
 			fun.args = append(fun.args, argvar)
 			if !argvar.optional() {
 				fun.reqargs[argvar.name] = true

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -670,7 +670,8 @@ func (g *generator) gatherDataSource(rawname string,
 		// Remember detailed information for every input arg (we will use it below).
 		docURL := fmt.Sprintf("%s#%s", parsedDocs.URL, arg)
 		if input(args[arg]) {
-			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", docURL, false /*out*/)
+			// Note: Although these are arguments, we pass `out` as true to ensure that the arguments do not get wrapped in `pulumi.Input`.
+			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", docURL, true /*out*/)
 			fun.args = append(fun.args, argvar)
 			if !argvar.optional() {
 				fun.reqargs[argvar.name] = true

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -304,7 +304,7 @@ func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 	}
 	if v.schema.Type != schema.TypeString {
 		// Only try to parse a JSON object if the config isn't a straight string.
-		getfunc = fmt.Sprintf("%sObject<%s>", getfunc, tsType(v, false /*noflags*/))
+		getfunc = fmt.Sprintf("%sObject<%s>", getfunc, tsType(v, false /*noflags*/, !v.out /*wrapInput*/))
 	}
 	var anycast string
 	if v.info != nil && v.info.Type != "" {
@@ -317,7 +317,7 @@ func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 		g.emitRawDocComment(w, v.rawdoc, "")
 	}
 	w.Writefmtln("export let %[1]s: %[2]s = %[3]s__config.%[4]s(\"%[1]s\");",
-		v.name, tsType(v, true /*noflags*/), anycast, getfunc)
+		v.name, tsType(v, true /*noflags*/, !v.out /*wrapInput*/), anycast, getfunc)
 }
 
 // sanitizeForDocComment ensures that no `*/` sequence appears in the string, to avoid
@@ -367,7 +367,7 @@ func (g *nodeJSGenerator) emitRawDocComment(w *tools.GenWriter, comment, prefix 
 	}
 }
 
-func (g *nodeJSGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType) {
+func (g *nodeJSGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType, wrapInput bool) {
 	if pot.doc != "" {
 		g.emitDocComment(w, pot.doc, "", "")
 	}
@@ -378,7 +378,7 @@ func (g *nodeJSGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType
 		} else if prop.rawdoc != "" {
 			g.emitRawDocComment(w, prop.rawdoc, "    ")
 		}
-		w.Writefmtln("    readonly %s%s: %s;", prop.name, tsFlags(prop), tsType(prop, false))
+		w.Writefmtln("    readonly %s%s: %s;", prop.name, tsFlags(prop), tsType(prop, false, wrapInput))
 	}
 	w.Writefmtln("}")
 }
@@ -444,7 +444,7 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		}
 
 		w.Writefmtln("    public %sreadonly %s: pulumi.Output<%s>;",
-			outcomment, prop.name, tsType(prop, true))
+			outcomment, prop.name, tsType(prop, true /*noflags*/, !prop.out /*wrapInput*/))
 	}
 	w.Writefmtln("")
 
@@ -509,11 +509,11 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 
 	// Emit the state type for get methods.
 	w.Writefmtln("")
-	g.emitPlainOldType(w, res.statet)
+	g.emitPlainOldType(w, res.statet, true /*wrapInput*/)
 
 	// Emit the argument type for construction.
 	w.Writefmtln("")
-	g.emitPlainOldType(w, res.argst)
+	g.emitPlainOldType(w, res.argst, true /*wrapInput*/)
 
 	return file, nil
 }
@@ -575,11 +575,11 @@ func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 	// If there are argument and/or return types, emit them.
 	if fun.argst != nil {
 		w.Writefmtln("")
-		g.emitPlainOldType(w, fun.argst)
+		g.emitPlainOldType(w, fun.argst, false /*wrapInput*/)
 	}
 	if fun.retst != nil {
 		w.Writefmtln("")
-		g.emitPlainOldType(w, fun.retst)
+		g.emitPlainOldType(w, fun.retst, false /*wrapInput*/)
 	}
 
 	return file, nil
@@ -861,15 +861,16 @@ func tsFlagsComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, opt bool, out
 	return ""
 }
 
-// tsType returns the TypeScript type name for a given schema property.  noflags may be passed as true to create a
-// type that represents the optional nature of a variable, even when flags will not be present; this is often needed
-// when turning the type into a generic type argument, for example, since there will be no opportunity for "?" there.
-func tsType(v *variable, noflags bool) string {
-	return tsTypeComplex(v.schema, v.info, noflags, v.out)
+// tsType returns the TypeScript type name for a given schema property.  noflags may be passed as true to create a type
+// that represents the optional nature of a variable, even when flags will not be present; this is often needed when
+// turning the type into a generic type argument, for example, since there will be no opportunity for "?" there.
+// wrapInput can be set to true to cause the generated type to be deeply wrapped with `pulumi.Input<T>`.
+func tsType(v *variable, noflags, wrapInput bool) string {
+	return tsTypeComplex(v.schema, v.info, noflags, v.out, wrapInput)
 }
 
 // tsTypeComplex is just like tsType, but permits recursing using component pieces rather than a true variable.
-func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out bool) string {
+func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out, wrapInput bool) string {
 	// First, see if there is a custom override.  If yes, use it directly.
 	var t string
 	var elem *tfbridge.SchemaInfo
@@ -883,12 +884,14 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 						t = fmt.Sprintf("%s | %s", t, at.Name())
 					}
 				}
+			}
+			if wrapInput {
 				t = fmt.Sprintf("pulumi.Input<%s>", t)
 			}
 		} else if info.Asset != nil {
 			t = "pulumi.asset." + info.Asset.Type()
 
-			if !out {
+			if wrapInput {
 				t = fmt.Sprintf("pulumi.Input<%s>", t)
 			}
 		}
@@ -899,7 +902,7 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 	// If nothing was found, generate the primitive type name for this.
 	if t == "" {
 		flatten := tfbridge.IsMaxItemsOne(sch, info)
-		t = tsPrimitive(sch.Type, sch.Elem, elem, flatten, out)
+		t = tsPrimitive(sch.Type, sch.Elem, elem, flatten, out, wrapInput)
 	}
 
 	// If we aren't using optional flags, we need to use TypeScript union types to permit undefined values.
@@ -913,7 +916,9 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 }
 
 // tsPrimitive returns the TypeScript type name for a given schema value type and element kind.
-func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.SchemaInfo, flatten, out bool) string {
+func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.SchemaInfo,
+	flatten, out, wrapInput bool) string {
+
 	// First figure out the raw type.
 	var t string
 	switch vt {
@@ -924,18 +929,18 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 	case schema.TypeString:
 		t = "string"
 	case schema.TypeSet, schema.TypeList:
-		elemType := tsElemType(elem, eleminfo, out)
+		elemType := tsElemType(elem, eleminfo, out, wrapInput)
 		if flatten {
 			return elemType
 		}
 		t = fmt.Sprintf("%s[]", elemType)
 	case schema.TypeMap:
-		t = fmt.Sprintf("{[key: string]: %v}", tsElemType(elem, eleminfo, out))
+		t = fmt.Sprintf("{[key: string]: %v}", tsElemType(elem, eleminfo, out, wrapInput))
 	default:
 		contract.Failf("Unrecognized schema type: %v", vt)
 	}
 
-	if !out {
+	if wrapInput {
 		t = fmt.Sprintf("pulumi.Input<%s>", t)
 	}
 
@@ -944,7 +949,7 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 
 // tsElemType returns the TypeScript type for a given schema element.  This element may be either a simple schema
 // property or a complex structure.  In the case of a complex structure, this will expand to its nominal type.
-func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out bool) string {
+func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput bool) string {
 	// If there is no element type specified, we will accept anything.
 	if elem == nil {
 		return "any"
@@ -952,10 +957,10 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out bool) string {
 
 	switch e := elem.(type) {
 	case schema.ValueType:
-		return tsPrimitive(e, nil, info, false, out)
+		return tsPrimitive(e, nil, info, false, out, wrapInput)
 	case *schema.Schema:
 		// A simple type, just return its type name.
-		return tsTypeComplex(e, info, true /*noflags*/, out)
+		return tsTypeComplex(e, info, true /*noflags*/, out, wrapInput)
 	case *schema.Resource:
 		// A complex type, just expand to its nominal type name.
 		// TODO: spill all complex structures in advance so that we don't have insane inline expansions.
@@ -972,13 +977,13 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out bool) string {
 					t += ", "
 				}
 				flg := tsFlagsComplex(sch, fldinfo, false, out)
-				typ := tsTypeComplex(sch, fldinfo, false /*noflags*/, out)
+				typ := tsTypeComplex(sch, fldinfo, false /*noflags*/, out, wrapInput)
 				t += fmt.Sprintf("%s%s: %s", name, flg, typ)
 				c++
 			}
 		}
 		t += " }"
-		if !out {
+		if wrapInput {
 			t = fmt.Sprintf("pulumi.Input<%s>", t)
 		}
 		return t

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -914,33 +914,31 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 // tsPrimitive returns the TypeScript type name for a given schema value type and element kind.
 func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.SchemaInfo, flatten, out bool) string {
 	// First figure out the raw type.
-	var t = (func() string {
-		switch vt {
-		case schema.TypeBool:
-			return "boolean"
-		case schema.TypeInt, schema.TypeFloat:
-			return "number"
-		case schema.TypeString:
-			return "string"
-		case schema.TypeSet, schema.TypeList:
-			elemType := tsElemType(elem, eleminfo, out)
-			if flatten {
-				return elemType
-			}
-			return fmt.Sprintf("%s[]", elemType)
-		case schema.TypeMap:
-			return fmt.Sprintf("{[key: string]: %v}", tsElemType(elem, eleminfo, out))
-		default:
-			contract.Failf("Unrecognized schema type: %v", vt)
-			return ""
+	var t string
+	switch vt {
+	case schema.TypeBool:
+		t = "boolean"
+	case schema.TypeInt, schema.TypeFloat:
+		t = "number"
+	case schema.TypeString:
+		t = "string"
+	case schema.TypeSet, schema.TypeList:
+		elemType := tsElemType(elem, eleminfo, out)
+		if flatten {
+			return elemType
 		}
-	})()
-
-	if out {
-		return t
+		t = fmt.Sprintf("%s[]", elemType)
+	case schema.TypeMap:
+		t = fmt.Sprintf("{[key: string]: %v}", tsElemType(elem, eleminfo, out))
+	default:
+		contract.Failf("Unrecognized schema type: %v", vt)
 	}
 
-	return fmt.Sprintf("pulumi.Input<%s>", t)
+	if !out {
+		t = fmt.Sprintf("pulumi.Input<%s>", t)
+	}
+
+	return t
 }
 
 // tsElemType returns the TypeScript type for a given schema element.  This element may be either a simple schema

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -977,7 +977,11 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out bool) string {
 				c++
 			}
 		}
-		return t + " }"
+		t += " }"
+		if !out {
+			t = fmt.Sprintf("pulumi.Input<%s>", t)
+		}
+		return t
 	default:
 		contract.Failf("Unrecognized schema element type: %v", e)
 		return ""

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -876,12 +876,13 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out b
 	if info != nil {
 		if info.Type != "" {
 			t = string(info.Type.Name())
-			if len(info.AltTypes) > 0 {
-				for _, at := range info.AltTypes {
-					t = fmt.Sprintf("%s | %s", t, at.Name())
-				}
-			}
 			if !out {
+				// Only include AltTypes on inputs, as outputs will always have a concrete type
+				if len(info.AltTypes) > 0 {
+					for _, at := range info.AltTypes {
+						t = fmt.Sprintf("%s | %s", t, at.Name())
+					}
+				}
 				t = fmt.Sprintf("pulumi.Input<%s>", t)
 			}
 		} else if info.Asset != nil {

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests that we convert from CamelCase resource names to pythonic
+// snake_case correctly.
+func Test_TsType(t *testing.T) {
+
+	// Schema output
+	assert.Equal(t, "string", tsType(&variable{
+		name: "foo",
+		schema: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		out: true,
+		opt: true,
+	}, false))
+
+	// Schema input
+	assert.Equal(t, "pulumi.Input<string>", tsType(&variable{
+		name: "foo",
+		schema: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		out: false,
+		opt: true,
+	}, false))
+
+	// AltTypes output
+	assert.Equal(t, "string | Foo", tsType(&variable{
+		name: "foo",
+		info: &tfbridge.SchemaInfo{
+			Type:     "string",
+			AltTypes: []tokens.Type{"Foo"},
+		},
+		out: true,
+		opt: true,
+	}, false))
+
+	// AltTypes input
+	assert.Equal(t, "pulumi.Input<string | Foo>", tsType(&variable{
+		name: "foo",
+		info: &tfbridge.SchemaInfo{
+			Type:     "string",
+			AltTypes: []tokens.Type{"Foo"},
+		},
+		out: false,
+		opt: true,
+	}, false))
+
+}
+
+func Test_Issue130(t *testing.T) {
+	schema := &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+
+	assert.Equal(t, "string", tsType(&variable{
+		name:   "condition",
+		schema: schema,
+		out:    true,
+	}, false))
+
+	assert.Equal(t, "pulumi.Input<string>", tsType(&variable{
+		name:   "condition",
+		schema: schema,
+		out:    false,
+	}, false))
+}

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -49,7 +49,7 @@ func Test_TsType(t *testing.T) {
 	}, false))
 
 	// AltTypes output
-	assert.Equal(t, "string | Foo", tsType(&variable{
+	assert.Equal(t, "string", tsType(&variable{
 		name: "foo",
 		info: &tfbridge.SchemaInfo{
 			Type:     "string",

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -36,7 +36,7 @@ func Test_TsType(t *testing.T) {
 		},
 		out: true,
 		opt: true,
-	}, false))
+	}, false, false))
 
 	// Schema input
 	assert.Equal(t, "pulumi.Input<string>", tsType(&variable{
@@ -46,7 +46,7 @@ func Test_TsType(t *testing.T) {
 		},
 		out: false,
 		opt: true,
-	}, false))
+	}, false, true))
 
 	// AltTypes output
 	assert.Equal(t, "string", tsType(&variable{
@@ -57,7 +57,7 @@ func Test_TsType(t *testing.T) {
 		},
 		out: true,
 		opt: true,
-	}, false))
+	}, false, false))
 
 	// AltTypes input
 	assert.Equal(t, "pulumi.Input<string | Foo>", tsType(&variable{
@@ -68,7 +68,7 @@ func Test_TsType(t *testing.T) {
 		},
 		out: false,
 		opt: true,
-	}, false))
+	}, false, true))
 
 }
 
@@ -83,11 +83,11 @@ func Test_Issue130(t *testing.T) {
 		name:   "condition",
 		schema: schema,
 		out:    true,
-	}, false))
+	}, false, false))
 
 	assert.Equal(t, "pulumi.Input<string>", tsType(&variable{
 		name:   "condition",
 		schema: schema,
 		out:    false,
-	}, false))
+	}, false, true))
 }


### PR DESCRIPTION
Fixes #204:  [BREAKING CHANGE] We no longer generate `Input<T>` types on inputs to invoked functions.  These functions do no return `Output<T>`, so cannot correctly consume `Input<T>` inputs.  Instead, they should be used inside an `apply` if needed to operate on outputs of another Pulumi resource.

Fixes #130: Avoid generating `pulumi.Input<pulumi.Input<T>>` for MaxItemsOne properties.

Fixes #216: Don't emit `AltTypes` on outputs.

Also adds some initial test coverage for Node.js type generation.