### PR TITLE
Adopt pulumi/pulumi#1684

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,7 +385,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "61324d554059ea96a89460d0ede30eaba4368fb3"
+  revision = "9bfea8e5c4b4b7522e00796397f72fe3f4984dd7"
 
 [[projects]]
   branch = "master"

--- a/pkg/tfbridge/serve.go
+++ b/pkg/tfbridge/serve.go
@@ -15,12 +15,10 @@
 package tfbridge
 
 import (
-	"log"
+	"context"
 
-	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource/provider"
 	lumirpc "github.com/pulumi/pulumi/sdk/proto/go"
-	"golang.org/x/net/context"
 )
 
 // Serve fires up a Pulumi resource provider listening to inbound gRPC traffic,
@@ -28,18 +26,7 @@ import (
 func Serve(module string, version string, info ProviderInfo) error {
 	// Create a new resource provider server and listen for and serve incoming connections.
 	return provider.Main(module, func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
-		// Set up a log redirector to capture Terraform provider logging and only pass through those that we need.
-		log.SetOutput(&LogRedirector{
-			writers: map[string]func(string) error{
-				tfTracePrefix: func(msg string) error { return host.Log(context.TODO(), diag.Debug, msg) },
-				tfDebugPrefix: func(msg string) error { return host.Log(context.TODO(), diag.Debug, msg) },
-				tfInfoPrefix:  func(msg string) error { return host.Log(context.TODO(), diag.Info, msg) },
-				tfWarnPrefix:  func(msg string) error { return host.Log(context.TODO(), diag.Warning, msg) },
-				tfErrorPrefix: func(msg string) error { return host.Log(context.TODO(), diag.Error, msg) },
-			},
-		})
-
 		// Create a new bridge provider.
-		return NewProvider(host, module, version, info.P, info), nil
+		return NewProvider(context.TODO(), host, module, version, info.P, info), nil
 	})
 }


### PR DESCRIPTION
In most of the places we log within tfbridge we do not have a URN to attach the logging context to - in particular, most output from TF providers is via stdout, which we cannot associate with a specific operation.

For logging results of `Check` calls though, we can associate these with the resource that is being checked.