### PR TITLE
Fix types and marshalling for Resource-Elem TypeMap values.

### DIFF
--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -60,6 +60,9 @@ func TestTerraformInputs(t *testing.T) {
 				"someValue":      true,
 				"someOtherValue": "a value",
 			},
+			"mapWithResourceElem": map[string]interface{}{
+				"someValue": "a value",
+			},
 		}),
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
@@ -94,6 +97,14 @@ func TestTerraformInputs(t *testing.T) {
 					Schema: map[string]*schema.Schema{
 						"some_value":       {Type: schema.TypeBool},
 						"some_other_value": {Type: schema.TypeString},
+					},
+				},
+			},
+			"map_with_resource_elem": {
+				Type: schema.TypeMap,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"some_value": {Type: schema.TypeString},
 					},
 				},
 			},
@@ -149,6 +160,11 @@ func TestTerraformInputs(t *testing.T) {
 			map[string]interface{}{
 				"some_value":       true,
 				"some_other_value": "a value",
+			},
+		},
+		"map_with_resource_elem": []interface{}{
+			map[string]interface{}{
+				"some_value": "a value",
 			},
 		},
 	}, result)

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -598,6 +598,11 @@ func goSchemaOutputType(sch *schema.Schema, info *tfbridge.SchemaInfo) string {
 			}
 			return "*pulumi.ArrayOutput"
 		case schema.TypeMap:
+			// If this map has a "resource" element type, just use the generated element type. This works around a bug
+			// in TF that effectively forces this behavior.
+			if _, hasResourceElem := sch.Elem.(*schema.Resource); hasResourceElem {
+				return goSchemaOutputType(nil, nil)
+			}
 			return "*pulumi.MapOutput"
 		}
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -958,7 +958,14 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 		}
 		t = fmt.Sprintf("%s[]", elemType)
 	case schema.TypeMap:
-		t = fmt.Sprintf("{[key: string]: %v}", tsElemType(elem, eleminfo, out, wrapInput))
+		// If this map has a "resource" element type, just use the generated element type. This works around a bug in
+		// TF that effectively forces this behavior.
+		elemType := tsElemType(elem, eleminfo, out, wrapInput)
+		if _, hasResourceElem := elem.(*schema.Resource); hasResourceElem {
+			t, wrapInput = elemType, false
+		} else {
+			t = fmt.Sprintf("{[key: string]: %v}", elemType)
+		}
 	default:
 		contract.Failf("Unrecognized schema type: %v", vt)
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -962,10 +962,9 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 		// TF that effectively forces this behavior.
 		elemType := tsElemType(elem, eleminfo, out, wrapInput)
 		if _, hasResourceElem := elem.(*schema.Resource); hasResourceElem {
-			t, wrapInput = elemType, false
-		} else {
-			t = fmt.Sprintf("{[key: string]: %v}", elemType)
+			return elemType
 		}
+		t = fmt.Sprintf("{[key: string]: %v}", elemType)
 	default:
 		contract.Failf("Unrecognized schema type: %v", vt)
 	}


### PR DESCRIPTION
Terraform maps are odd, to say the least. In general a map value may be
either a list of string -> value maps or a string -> value map itself.
Maps that have an element type that is a *schema.Resource, however, must
be lists of string -> value maps.

These changes update the Pulumi -> TF config marshaller so that in the
latter case we appropriately wrap input maps in an array. The codegen
for Node and Go has also been updated to accurately reflect the type.

Fixes #231.