### PR TITLE
Project default values from literals or envvars.

### DIFF
--- a/Gometalinter.json
+++ b/Gometalinter.json
@@ -5,7 +5,6 @@
         "deadcode",
         "errcheck",
         "gas",
-        "goconst",
         "gofmt",
         "golint",
         "ineffassign",

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -96,8 +96,13 @@ func (info SchemaInfo) HasDefault() bool {
 
 // DefaultInfo lets fields get default values at runtime, before they are even passed to Terraform.
 type DefaultInfo struct {
-	From  func(res *PulumiResource) (interface{}, error) // a transformation from other resource properties.
-	Value interface{}                                    // a raw value to inject.
+	// a transformation from other resource properties.
+	From func(res *PulumiResource) (interface{}, error)
+	// a raw value to inject.
+	Value interface{}
+	// EnvVars to use for defaults. If none of these variables have values at runtime, the value of `Value` (if any)
+	// will be used as the default.
+	EnvVars []string
 }
 
 // PulumiResource is just a little bundle that carries URN and properties around.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -95,6 +95,10 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 					}
 					result[name] = v
 					glog.V(9).Infof("Created Terraform input: %v = %v (old default)", key, old)
+				} else if envVars := info.Default.EnvVars; len(envVars) != 0 {
+					result[name] = schema.MultiEnvDefaultFunc(envVars, info.Default.Value)
+					glog.V(9).Infof("Created Terraform input: %v = %v (defualt from env vars)", name, result[name])
+
 				} else if info.Default.Value != nil {
 					result[name] = info.Default.Value
 					glog.V(9).Infof("Created Terraform input: %v = %v (default)", name, result[name])
@@ -103,7 +107,6 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 					if err != nil {
 						return nil, err
 					}
-
 					result[name] = v
 					glog.V(9).Infof("Created Terraform input: %v = %v (default from fnc)", name, result[name])
 				}
@@ -603,6 +606,7 @@ func MakeTerraformAttributesFromInputs(inputs map[string]interface{},
 
 		flattenValue(result, k, f.Value)
 	}
+
 	return result, nil
 }
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -97,7 +97,7 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 					glog.V(9).Infof("Created Terraform input: %v = %v (old default)", key, old)
 				} else if envVars := info.Default.EnvVars; len(envVars) != 0 {
 					result[name] = schema.MultiEnvDefaultFunc(envVars, info.Default.Value)
-					glog.V(9).Infof("Created Terraform input: %v = %v (defualt from env vars)", name, result[name])
+					glog.V(9).Infof("Created Terraform input: %v = %v (default from env vars)", name, result[name])
 
 				} else if info.Default.Value != nil {
 					result[name] = info.Default.Value

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -208,7 +208,7 @@ type variable struct {
 	name   string
 	out    bool
 	opt    bool
-	config bool
+	config bool // config is true if this variable represents a Pulumi config value.
 	doc    string
 	rawdoc string
 	schema *schema.Schema

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -164,6 +164,11 @@ func (m *module) config() bool {
 	return m.name == configMod
 }
 
+// root returns true if this is the root module for a package.
+func (m *module) root() bool {
+	return m.name == ""
+}
+
 // addMember appends a new member.  This maintains ordering in case the code is sensitive to declaration order.
 func (m *module) addMember(member moduleMember) {
 	name := member.Name()
@@ -203,6 +208,7 @@ type variable struct {
 	name   string
 	out    bool
 	opt    bool
+	config bool
 	doc    string
 	rawdoc string
 	schema *schema.Schema
@@ -215,15 +221,15 @@ func (v *variable) Doc() string  { return v.doc }
 
 // optional checks whether the given property is optional, either due to Terraform or an overlay.
 func (v *variable) optional() bool {
-	return v.opt || optionalComplex(v.schema, v.info, v.out)
+	return v.opt || optionalComplex(v.schema, v.info, v.out, v.config)
 }
 
 // optionalComplex takes the constituent parts of a variable, rather than a variable itself, and returns whether it is
 // optional based on the Terraform or custom overlay properties.
-func optionalComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool) bool {
+func optionalComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, out, config bool) bool {
 	// If we're checking a property used in an output position, it isn't optional if it's computed.
 	customDefault := info != nil && info.HasDefault()
-	if out {
+	if out && !config {
 		return sch.Optional && !sch.Computed && !customDefault
 	}
 	return sch.Optional || sch.Computed || customDefault
@@ -443,6 +449,7 @@ func (g *generator) gatherConfig() *module {
 		sch := cfg[key]
 		docURL := fmt.Sprintf("https://www.terraform.io/docs/providers/%s/", g.info.Name)
 		if prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/); prop != nil {
+			prop.config = true
 			config.addMember(prop)
 		}
 	}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -228,8 +228,10 @@ func (v *variable) optional() bool {
 // optional based on the Terraform or custom overlay properties.
 func optionalComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, out, config bool) bool {
 	// If we're checking a property used in an output position, it isn't optional if it's computed.
-	customDefault := info != nil && info.HasDefault()
-	if out && !config {
+	//
+	// Note that config values with custom defaults are _not_ considered optional unless they are marked as such.
+	customDefault := !config && info != nil && info.HasDefault()
+	if out {
 		return sch.Optional && !sch.Computed && !customDefault
 	}
 	return sch.Optional || sch.Computed || customDefault

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -277,7 +277,7 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 		w.Writefmtln("\t\treturn dv")
 		w.Writefmtln("\t}")
 		if !v.optional() {
-			w.Writefmtln("\tcontract.Failf(err.Error())")
+			w.Writefmtln("\tpanic(err.Error())")
 		}
 		w.Writefmtln("\treturn v")
 	} else {

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -18,12 +18,15 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/tools"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
@@ -46,6 +49,7 @@ type goGenerator struct {
 	info        tfbridge.ProviderInfo
 	overlaysDir string
 	outDir      string
+	needsUtils  bool
 }
 
 // commentChars returns the comment characters to use for single-line comments.
@@ -147,6 +151,8 @@ func (g *goGenerator) emitModules(mmap moduleMap) error {
 func (g *goGenerator) emitModule(mod *module) error {
 	glog.V(3).Infof("emitModule(%s)", mod.name)
 
+	defer func() { g.needsUtils = false }()
+
 	// Ensure that the target module directory exists.
 	dir := g.moduleDir(mod)
 	if err := tools.EnsureDir(dir); err != nil {
@@ -164,6 +170,13 @@ func (g *goGenerator) emitModule(mod *module) error {
 	if mod.config() {
 		if err := g.emitConfigVariables(mod); err != nil {
 			return errors.Wrapf(err, "emitting config module variables")
+		}
+	}
+
+	// If any part of this module needs internal utilities, emit them now.
+	if g.needsUtils {
+		if err := g.emitUtilities(mod); err != nil {
+			return errors.Wrapf(err, "emitting utilities file")
 		}
 	}
 
@@ -253,9 +266,39 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 	} else if v.rawdoc != "" {
 		g.emitRawDocComment(w, v.rawdoc, "")
 	}
+
+	defaultValue := ""
+	if v.optional() {
+		defaultValue = g.goDefaultValue(v)
+	}
+
 	w.Writefmtln("func Get%s(ctx *pulumi.Context) %s {", upperFirst(v.name), gettype)
-	w.Writefmtln("\treturn config.%s(ctx, \"%s:%s\")", getfunc, g.pkg, v.name)
+
+	configKey := fmt.Sprintf("\"%s:%s\"", g.pkg, v.name)
+	if defaultValue != "" {
+		w.Writefmtln("\tif v := config.Get(ctx, %s); v != \"\" {", configKey)
+		w.Writefmtln("\t\treturn config.%s(ctx, %s)", getfunc, configKey)
+		w.Writefmtln("\t}")
+		w.Writefmtln("\treturn %s", defaultValue)
+	} else {
+		w.Writefmtln("\treturn config.%s(ctx, \"%s:%s\")", getfunc, g.pkg, v.name)
+	}
+
 	w.Writefmtln("}")
+}
+
+// emitUtilities
+func (g *goGenerator) emitUtilities(mod *module) error {
+	// Open the utilities.ts file for this module and ready it for writing.
+	w, err := g.openWriter(mod, "internal_utilities.go", imports{})
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(w)
+
+	// TODO: use w.WriteString
+	w.Writefmt(goUtilitiesFile)
+	return nil
 }
 
 func (g *goGenerator) emitDocComment(w *tools.GenWriter, comment, docURL, prefix string) {
@@ -364,9 +407,18 @@ func (g *goGenerator) emitResourceType(mod *module, res *resourceType) error {
 
 	// Produce the input map.
 	w.Writefmtln("\tinputs := make(map[string]interface{})")
+	hasDefault := make(map[*variable]bool)
+	for _, prop := range res.inprops {
+		if defaultValue := g.goDefaultValue(prop); defaultValue != "" {
+			hasDefault[prop] = true
+			w.Writefmtln("\tinputs[\"%s\"] = %s", prop.name, defaultValue)
+		}
+	}
 	w.Writefmtln("\tif args == nil {")
 	for _, prop := range res.inprops {
-		w.Writefmtln("\t\tinputs[\"%s\"] = nil", prop.name)
+		if !hasDefault[prop] {
+			w.Writefmtln("\t\tinputs[\"%s\"] = nil", prop.name)
+		}
 	}
 	w.Writefmtln("\t} else {")
 	for _, prop := range res.inprops {
@@ -608,4 +660,76 @@ func goSchemaOutputType(sch *schema.Schema, info *tfbridge.SchemaInfo) string {
 	}
 
 	return defaultGoOutType
+}
+
+func goPrimitiveValue(value interface{}) (string, error) {
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			return "true", nil
+		}
+		return "false", nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return strconv.FormatInt(v.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return strconv.FormatUint(v.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64), nil
+	case reflect.String:
+		return fmt.Sprintf("%q", v.String()), nil
+	default:
+		return "", errors.Errorf("unsupported default value of type %T", value)
+	}
+}
+
+func (g *goGenerator) goDefaultValue(v *variable) string {
+	defaultValue := ""
+	if v.info == nil || v.info.Default == nil {
+		return defaultValue
+	}
+	defaults := v.info.Default
+
+	if defaults.Value != nil {
+		dv, err := goPrimitiveValue(defaults.Value)
+		if err != nil {
+			cmdutil.Diag().Warningf(diag.Message("", err.Error()))
+			return defaultValue
+		}
+		defaultValue = dv
+	}
+
+	if len(defaults.EnvVars) > 0 {
+		g.needsUtils = true
+
+		parser, outDefault := "nil", "\"\""
+		switch v.schema.Type {
+		case schema.TypeBool:
+			parser, outDefault = "parseEnvBool", "false"
+		case schema.TypeInt:
+			parser, outDefault = "parseEnvInt", "0"
+		case schema.TypeFloat:
+			parser, outDefault = "parseEnvFloat", "0.0"
+		}
+
+		if defaultValue == "" {
+			if v.out {
+				defaultValue = outDefault
+			} else {
+				defaultValue = "nil"
+			}
+		}
+
+		defaultValue = fmt.Sprintf("getEnvOrDefault(%s, %s", defaultValue, parser)
+		for _, e := range defaults.EnvVars {
+			defaultValue += fmt.Sprintf(", %q", e)
+		}
+		defaultValue += ")"
+	}
+
+	return defaultValue
 }

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -246,7 +246,8 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 		getfunc = "Require"
 	}
 
-	gettype, functype := "", ""
+	var gettype string
+	var functype string
 	switch v.schema.Type {
 	case schema.TypeBool:
 		gettype, functype = "bool", "Bool"
@@ -255,7 +256,7 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 	case schema.TypeFloat:
 		gettype, functype = "float64", "Float64"
 	default:
-		gettype = "string"
+		gettype, functype = "string", ""
 	}
 
 	if v.doc != "" {

--- a/pkg/tfgen/generate_go_utilities.go
+++ b/pkg/tfgen/generate_go_utilities.go
@@ -1,0 +1,45 @@
+package tfgen
+
+const goUtilitiesFile = `
+import (
+	"os"
+	"strconv"
+)
+
+type envParser func(v string) interface{}
+
+func parseEnvBool(v string) interface{} {
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func parseEnvInt(v string) interface{} {
+	i, err := strconv.ParseInt(v, 0, 0)
+	if err != nil {
+		return nil
+	}
+	return int(i)
+}
+
+func parseEnvFloat(v string) interface{} {
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return nil
+	}
+	return f
+}
+
+func getEnvOrDefault(def interface{}, parser envParser, vars ...string) interface{} {
+	for _, v := range vars {
+		if value := os.Getenv(v); value != "" {
+			if parser != nil {
+				return parser(value)
+			}
+			return value
+		}
+	}
+	return def
+}`

--- a/pkg/tfgen/generate_go_utilities.go
+++ b/pkg/tfgen/generate_go_utilities.go
@@ -42,4 +42,5 @@ func getEnvOrDefault(def interface{}, parser envParser, vars ...string) interfac
 		}
 	}
 	return def
-}`
+}
+`

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -20,13 +20,16 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/tools"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
@@ -65,6 +68,13 @@ func (g *nodeJSGenerator) moduleDir(mod *module) string {
 	return dir
 }
 
+// relativeRootDir returns the relative path to the root directory for the given module.
+func (g *nodeJSGenerator) relativeRootDir(mod *module) string {
+	p, err := filepath.Rel(g.moduleDir(mod), g.outDir)
+	contract.IgnoreError(err)
+	return p
+}
+
 // openWriter opens a writer for the given module and file name, emitting the standard header automatically.
 func (g *nodeJSGenerator) openWriter(mod *module, name string, needsSDK bool) (*tools.GenWriter, string, error) {
 	dir := g.moduleDir(mod)
@@ -79,14 +89,15 @@ func (g *nodeJSGenerator) openWriter(mod *module, name string, needsSDK bool) (*
 
 	// If needed, emit the standard Pulumi SDK import statement.
 	if needsSDK {
-		g.emitSDKImport(w)
+		g.emitSDKImport(mod, w)
 	}
 
 	return w, file, nil
 }
 
-func (g *nodeJSGenerator) emitSDKImport(w *tools.GenWriter) {
+func (g *nodeJSGenerator) emitSDKImport(mod *module, w *tools.GenWriter) {
 	w.Writefmtln("import * as pulumi from \"@pulumi/pulumi\";")
+	w.Writefmtln("import * as utilities from \"%s/utilities\";", g.relativeRootDir(mod))
 	w.Writefmtln("")
 }
 
@@ -98,7 +109,7 @@ func (g *nodeJSGenerator) emitPackage(pack *pkg) error {
 		return err
 	}
 
-	// Generate a top-level index file that re-exports any child modules.
+	// Generate a top-level index file that re-exports any child modules and a top-level utils file.
 	index := pack.modules.ensureModule("")
 	if pack.provider != nil {
 		index.members = append(index.members, pack.provider)
@@ -178,12 +189,22 @@ func (g *nodeJSGenerator) emitModule(mod *module, submods map[string]string) ([]
 		files = append(files, file)
 	}
 
-	// Lastly, generate an index file for this module.
+	// Generate an index file for this module.
 	index, err := g.emitIndex(mod, files, submods)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "emitting module %s index", mod.name)
 	}
 	files = append(files, index)
+
+	// Lastly, if this is the root module, we need to emit a file containing utility functions consumed by other
+	// modules.
+	if mod.root() {
+		utils, err := g.emitUtilities(mod)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "emitting utility file for root module")
+		}
+		files = append(files, utils)
+	}
 
 	return files, index, nil
 }
@@ -241,6 +262,22 @@ func (g *nodeJSGenerator) emitIndex(mod *module, exports []string, submods map[s
 	}
 
 	return index, nil
+}
+
+// emitUtilities emits a utilities file for submodules to consume.
+func (g *nodeJSGenerator) emitUtilities(mod *module) (string, error) {
+	contract.Require(mod.root(), "mod.root()")
+
+	// Open the utilities.ts file for this module and ready it for writing.
+	w, utilities, err := g.openWriter(mod, "utilities.ts", false)
+	if err != nil {
+		return "", err
+	}
+	defer contract.IgnoreClose(w)
+
+	// TODO: use w.WriteString
+	w.Writefmt(tsUtilitiesFile)
+	return utilities, nil
 }
 
 // emitModuleMember emits the given member, and returns the module file that it was emitted into (if any).
@@ -320,8 +357,16 @@ func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 	} else if v.rawdoc != "" {
 		g.emitRawDocComment(w, v.rawdoc, "")
 	}
-	w.Writefmtln("export let %[1]s: %[2]s = %[3]s__config.%[4]s(\"%[1]s\");",
-		v.name, tsType(v, true /*noflags*/, !v.out /*wrapInput*/), anycast, getfunc)
+
+	defaultValue := ""
+	if v.optional() {
+		if dv := tsDefaultValue(v); dv != "undefined" {
+			defaultValue = " || " + dv
+		}
+	}
+
+	w.Writefmtln("export let %[1]s: %[2]s = %[3]s__config.%[4]s(\"%[1]s\")%[5]s;",
+		v.name, tsType(v, true /*noflags*/, !v.out /*wrapInput*/), anycast, getfunc, defaultValue)
 }
 
 // sanitizeForDocComment ensures that no `*/` sequence appears in the string, to avoid
@@ -517,7 +562,11 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		}
 	}
 	for _, prop := range res.inprops {
-		w.Writefmtln(`            inputs["%[1]s"] = args ? args.%[1]s : undefined;`, prop.name)
+		arg := fmt.Sprintf("args ? args.%[1]s : undefined", prop.name)
+		if defaultValue := tsDefaultValue(prop); defaultValue != "undefined" {
+			arg = fmt.Sprintf("(%s) || %s", arg, defaultValue)
+		}
+		w.Writefmtln(`            inputs["%s"] = %s;`, prop.name, arg)
 	}
 	for _, prop := range res.outprops {
 		if !ins[prop.name] {
@@ -878,12 +927,12 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 
 // tsFlags returns the TypeScript flags for a given variable.
 func tsFlags(v *variable) string {
-	return tsFlagsComplex(v.schema, v.info, v.opt, v.out)
+	return tsFlagsComplex(v.schema, v.info, v.opt, v.out, v.config)
 }
 
 // tsFlagsComplex is just like tsFlags, except that it permits recursing into component pieces individually.
-func tsFlagsComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, opt bool, out bool) string {
-	if opt || optionalComplex(sch, info, out) {
+func tsFlagsComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, opt, out, config bool) string {
+	if opt || optionalComplex(sch, info, out, config) {
 		return "?"
 	}
 	return ""
@@ -894,11 +943,11 @@ func tsFlagsComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, opt bool, out
 // turning the type into a generic type argument, for example, since there will be no opportunity for "?" there.
 // wrapInput can be set to true to cause the generated type to be deeply wrapped with `pulumi.Input<T>`.
 func tsType(v *variable, noflags, wrapInput bool) string {
-	return tsTypeComplex(v.schema, v.info, noflags, v.out, wrapInput)
+	return tsTypeComplex(v.schema, v.info, noflags, v.out, wrapInput, v.config)
 }
 
 // tsTypeComplex is just like tsType, but permits recursing using component pieces rather than a true variable.
-func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out, wrapInput bool) string {
+func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out, wrapInput, config bool) string {
 	// First, see if there is a custom override.  If yes, use it directly.
 	var t string
 	var elem *tfbridge.SchemaInfo
@@ -930,12 +979,12 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out, 
 	// If nothing was found, generate the primitive type name for this.
 	if t == "" {
 		flatten := tfbridge.IsMaxItemsOne(sch, info)
-		t = tsPrimitive(sch.Type, sch.Elem, elem, flatten, out, wrapInput)
+		t = tsPrimitive(sch.Type, sch.Elem, elem, flatten, out, wrapInput, config)
 	}
 
 	// If we aren't using optional flags, we need to use TypeScript union types to permit undefined values.
 	if noflags {
-		if opt := optionalComplex(sch, info, out); opt {
+		if opt := optionalComplex(sch, info, out, config); opt {
 			t += " | undefined"
 		}
 	}
@@ -945,7 +994,7 @@ func tsTypeComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, noflags, out, 
 
 // tsPrimitive returns the TypeScript type name for a given schema value type and element kind.
 func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.SchemaInfo,
-	flatten, out, wrapInput bool) string {
+	flatten, out, wrapInput, config bool) string {
 
 	// First figure out the raw type.
 	var t string
@@ -957,7 +1006,7 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 	case schema.TypeString:
 		t = "string"
 	case schema.TypeSet, schema.TypeList:
-		elemType := tsElemType(elem, eleminfo, out, wrapInput)
+		elemType := tsElemType(elem, eleminfo, out, wrapInput, config)
 		if flatten {
 			return elemType
 		}
@@ -965,7 +1014,7 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 	case schema.TypeMap:
 		// If this map has a "resource" element type, just use the generated element type. This works around a bug in
 		// TF that effectively forces this behavior.
-		elemType := tsElemType(elem, eleminfo, out, wrapInput)
+		elemType := tsElemType(elem, eleminfo, out, wrapInput, config)
 		if _, hasResourceElem := elem.(*schema.Resource); hasResourceElem {
 			return elemType
 		}
@@ -983,7 +1032,7 @@ func tsPrimitive(vt schema.ValueType, elem interface{}, eleminfo *tfbridge.Schem
 
 // tsElemType returns the TypeScript type for a given schema element.  This element may be either a simple schema
 // property or a complex structure.  In the case of a complex structure, this will expand to its nominal type.
-func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput bool) string {
+func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput, config bool) string {
 	// If there is no element type specified, we will accept anything.
 	if elem == nil {
 		return "any"
@@ -991,10 +1040,10 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput bool
 
 	switch e := elem.(type) {
 	case schema.ValueType:
-		return tsPrimitive(e, nil, info, false, out, wrapInput)
+		return tsPrimitive(e, nil, info, false, out, wrapInput, config)
 	case *schema.Schema:
 		// A simple type, just return its type name.
-		return tsTypeComplex(e, info, true /*noflags*/, out, wrapInput)
+		return tsTypeComplex(e, info, true /*noflags*/, out, wrapInput, config)
 	case *schema.Resource:
 		// A complex type, just expand to its nominal type name.
 		// TODO: spill all complex structures in advance so that we don't have insane inline expansions.
@@ -1010,8 +1059,8 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput bool
 				if c > 0 {
 					t += ", "
 				}
-				flg := tsFlagsComplex(sch, fldinfo, false, out)
-				typ := tsTypeComplex(sch, fldinfo, false /*noflags*/, out, wrapInput)
+				flg := tsFlagsComplex(sch, fldinfo, false, out, config)
+				typ := tsTypeComplex(sch, fldinfo, false /*noflags*/, out, wrapInput, config)
 				t += fmt.Sprintf("%s%s: %s", name, flg, typ)
 				c++
 			}
@@ -1025,4 +1074,70 @@ func tsElemType(elem interface{}, info *tfbridge.SchemaInfo, out, wrapInput bool
 		contract.Failf("Unrecognized schema element type: %v", e)
 		return ""
 	}
+}
+
+func tsPrimitiveValue(value interface{}) (string, error) {
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			return "true", nil
+		}
+		return "false", nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return strconv.FormatInt(v.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return strconv.FormatUint(v.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64), nil
+	case reflect.String:
+		return fmt.Sprintf("%q", v.String()), nil
+	default:
+		return "", errors.Errorf("unsupported default value of type %T", value)
+	}
+}
+
+func tsDefaultValue(prop *variable) string {
+	defaultValue := "undefined"
+	if prop.info == nil || prop.info.Default == nil {
+		return defaultValue
+	}
+	defaults := prop.info.Default
+
+	if defaults.Value != nil {
+		dv, err := tsPrimitiveValue(defaults.Value)
+		if err != nil {
+			cmdutil.Diag().Warningf(diag.Message("", err.Error()))
+			return defaultValue
+		}
+		defaultValue = dv
+	}
+
+	if len(defaults.EnvVars) != 0 {
+		getType := ""
+		switch prop.schema.Type {
+		case schema.TypeBool:
+			getType = "Boolean"
+		case schema.TypeInt, schema.TypeFloat:
+			getType = "Number"
+		}
+
+		envVars := fmt.Sprintf("%q", defaults.EnvVars[0])
+		for _, e := range defaults.EnvVars[1:] {
+			envVars += fmt.Sprintf(", %q", e)
+		}
+
+		getEnv := fmt.Sprintf("utilities.getEnv%s(%s)", getType, envVars)
+		if defaultValue != "undefined" {
+			defaultValue = fmt.Sprintf("(%s || %s)", getEnv, defaultValue)
+		} else {
+			defaultValue = getEnv
+		}
+	}
+
+	return defaultValue
 }

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -14,6 +14,8 @@ export function getEnv(...vars: string[]): string | undefined {
 export function getEnvBoolean(...vars: string[]): boolean | undefined {
     const s = getEnv(...vars);
     if (s !== undefined) {
+        // NOTE: these values are taken from https://golang.org/src/strconv/atob.go?s=351:391#L1, which is what
+        // Terraform uses internally when parsing boolean values.
         if (["1", "t", "T", "true", "TRUE", "True"].find(v => v === s) !== undefined) {
             return true;
         }

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -36,13 +36,13 @@ export function getEnvNumber(...vars: string[]): number | undefined {
 }
 
 export function requireWithDefault<T>(req: () => T, def: T | undefined): T {
-	try {
-		return req();
-	} catch (err) {
-		if (def === undefined) {
-			throw err;
-		}
-	}
-	return def;
+    try {
+        return req();
+    } catch (err) {
+        if (def === undefined) {
+            throw err;
+        }
+    }
+    return def;
 }
 `

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -1,0 +1,37 @@
+package tfgen
+
+const tsUtilitiesFile = `
+export function getEnv(...vars: string[]): string | undefined {
+    for (const v of vars) {
+        const value = process.env[v];
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+export function getEnvBoolean(...vars: string[]): boolean | undefined {
+    const s = getEnv(...vars);
+    if (s !== undefined) {
+        if (["1", "t", "T", "true", "TRUE", "True"].find(v => v === s) !== undefined) {
+            return true;
+        }
+        if (["0", "f", "F", "false", "FALSE", "False"].find(v => v === s) !== undefined) {
+            return false;
+        }
+    }
+    return undefined;
+}
+
+export function getEnvNumber(...vars: string[]): number | undefined {
+    const s = getEnv(...vars);
+    if (s !== undefined) {
+        const f = parseFloat(s);
+        if (!isNaN(f)) {
+            return f;
+        }
+    }
+    return undefined;
+}
+`

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -34,4 +34,15 @@ export function getEnvNumber(...vars: string[]): number | undefined {
     }
     return undefined;
 }
+
+export function requireWithDefault<T>(req: () => T, def: T | undefined): T {
+	try {
+		return req();
+	} catch (err) {
+		if (def === undefined) {
+			throw err;
+		}
+	}
+	return def;
+}
 `

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -15,9 +15,11 @@
 package tfgen
 
 import (
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -25,7 +27,9 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
 
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/tools"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
@@ -64,6 +68,13 @@ func (g *pythonGenerator) moduleDir(mod *module) string {
 	return dir
 }
 
+// relativeRootDir returns the relative path to the root directory for the given module.
+func (g *pythonGenerator) relativeRootDir(mod *module) string {
+	p, err := filepath.Rel(g.moduleDir(mod), filepath.Join(g.outDir, pyPack(g.pkg)))
+	contract.IgnoreError(err)
+	return p
+}
+
 // openWriter opens a writer for the given module and file name, emitting the standard header automatically.
 func (g *pythonGenerator) openWriter(mod *module, name string, needsSDK bool) (*tools.GenWriter, error) {
 	dir := g.moduleDir(mod)
@@ -81,15 +92,16 @@ func (g *pythonGenerator) openWriter(mod *module, name string, needsSDK bool) (*
 
 	// If needed, emit the standard Pulumi SDK import statement.
 	if needsSDK {
-		g.emitSDKImport(w)
+		g.emitSDKImport(mod, w)
 	}
 
 	return w, nil
 }
 
-func (g *pythonGenerator) emitSDKImport(w *tools.GenWriter) {
+func (g *pythonGenerator) emitSDKImport(mod *module, w *tools.GenWriter) {
 	w.Writefmtln("import pulumi")
 	w.Writefmtln("import pulumi.runtime")
+	w.Writefmtln("from %s import utilities", g.relativeRootDir(mod))
 	w.Writefmtln("")
 }
 
@@ -173,6 +185,13 @@ func (g *pythonGenerator) emitModule(mod *module, submods []string) error {
 		exports = append(exports, m)
 	}
 
+	// If this is the root module, we need to emit the utilities.
+	if mod.root() {
+		if err := g.emitUtilities(mod); err != nil {
+			return errors.Wrap(err, "emitting utilities")
+		}
+	}
+
 	// Lastly, generate an index file for this module.
 	if err := g.emitIndex(mod, exports, submods); err != nil {
 		return errors.Wrapf(err, "emitting module %s index", mod.name)
@@ -214,6 +233,22 @@ func (g *pythonGenerator) emitIndex(mod *module, exports, submods []string) erro
 		}
 	}
 
+	return nil
+}
+
+// emitUtilities emits a utilities file for submodules to consume.
+func (g *pythonGenerator) emitUtilities(mod *module) error {
+	contract.Require(mod.root(), "mod.root()")
+
+	// Open the utilities.ts file for this module and ready it for writing.
+	w, err := g.openWriter(mod, "utilities.py", false)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(w)
+
+	// TODO: use w.WriteString
+	w.Writefmt(pyUtilitiesFile)
 	return nil
 }
 
@@ -265,12 +300,16 @@ func (g *pythonGenerator) emitConfigVariables(mod *module) (string, error) {
 
 func (g *pythonGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 	var getfunc string
+	var orDefaultValue string
 	if v.optional() {
 		getfunc = "get"
+		if dv := pyDefaultValue(v); dv != "" {
+			orDefaultValue = " or " + dv
+		}
 	} else {
 		getfunc = "require"
 	}
-	w.Writefmtln("%s = __config__.%s('%s')", pyName(v.name), getfunc, v.name)
+	w.Writefmtln("%s = __config__.%s('%s')%s", pyName(v.name), getfunc, v.name, orDefaultValue)
 	if v.doc != "" {
 		g.emitDocComment(w, v.doc, "")
 	} else if v.rawdoc != "" {
@@ -399,9 +438,15 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 
 	ins := make(map[string]bool)
 	for _, prop := range res.inprops {
-		// Check that required arguments are present.  Also check that types are as expected.
 		pname := pyName(prop.name)
 		ptype := pyType(prop)
+
+		// Fill in computed defaults for arguments.
+		if defaultValue := pyDefaultValue(prop); defaultValue != "" {
+			w.Writefmtln("        %s = %s", pname, defaultValue)
+		}
+
+		// Check that required arguments are present.  Also check that types are as expected.
 		if !prop.optional() {
 			w.Writefmtln("        if not %s:", pname)
 			w.Writefmtln("            raise TypeError('Missing required property %s')", pname)
@@ -862,4 +907,70 @@ func ensurePythonKeywordSafe(name string) string {
 		return name + "_"
 	}
 	return name
+}
+
+func pyPrimitiveValue(value interface{}) (string, error) {
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			return "True", nil
+		}
+		return "False", nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return strconv.FormatInt(v.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return strconv.FormatUint(v.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64), nil
+	case reflect.String:
+		return fmt.Sprintf("%q", v.String()), nil
+	default:
+		return "", errors.Errorf("unsupported default value of type %T", value)
+	}
+}
+
+func pyDefaultValue(v *variable) string {
+	defaultValue := ""
+	if v.info == nil || v.info.Default == nil {
+		return defaultValue
+	}
+	defaults := v.info.Default
+
+	if defaults.Value != nil {
+		dv, err := pyPrimitiveValue(defaults.Value)
+		if err != nil {
+			cmdutil.Diag().Warningf(diag.Message("", err.Error()))
+			return defaultValue
+		}
+		defaultValue = dv
+	}
+
+	if len(defaults.EnvVars) > 0 {
+		envFunc := "utilities.get_env"
+		switch v.schema.Type {
+		case schema.TypeBool:
+			envFunc = "utilities.get_env_bool"
+		case schema.TypeInt:
+			envFunc = "utilities.get_env_int"
+		case schema.TypeFloat:
+			envFunc = "utilities.get_env_float"
+		}
+
+		envVars := fmt.Sprintf("%q", defaults.EnvVars[0])
+		for _, e := range defaults.EnvVars[1:] {
+			envVars += fmt.Sprintf(", %q", e)
+		}
+		if defaultValue == "" {
+			defaultValue = fmt.Sprintf("%s(%s)", envFunc, envVars)
+		} else {
+			defaultValue = fmt.Sprintf("(%s(%s) or %s)", envFunc, envVars, defaultValue)
+		}
+	}
+
+	return defaultValue
 }

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -311,7 +311,7 @@ func (g *pythonGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 		if v.optional() {
 			configFetch += " or " + defaultValue
 		} else {
-			configFetch = fmt.Sprintf("utilities.requireWithDefault(lambda: %s, %s)", configFetch, defaultValue)
+			configFetch = fmt.Sprintf("utilities.require_with_default(lambda: %s, %s)", configFetch, defaultValue)
 		}
 	}
 

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -1,0 +1,39 @@
+package tfgen
+
+const pyUtilitiesFile = `
+import os
+
+def get_env(*args):
+    for v in args:
+        value = os.getenv(v)
+        if value is not None:
+            return value
+    return None
+
+def get_env_bool(*args):
+    str = get_env(*args)
+    if str is not None:
+        if str in ["1", "t", "T", "true", "TRUE", "True"]:
+            return True
+        if str in ["0", "f", "F", "false", "FALSE", "False"]:
+            return False
+    return None
+
+def get_env_int(*args):
+    str = get_env(*args)
+    if str is not None:
+        try:
+            return int(str)
+        except:
+            return None
+    return None
+
+def get_env_float(*args):
+    str = get_env(*args)
+    if str is not None:
+        try:
+            return float(str)
+        except:
+            return None
+    return None
+`

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -36,4 +36,12 @@ def get_env_float(*args):
         except:
             return None
     return None
+
+def require_with_default(req, def):
+	try:
+		return req()
+	except:
+		if def is not None:
+			return def
+		raise
 `

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -37,11 +37,11 @@ def get_env_float(*args):
             return None
     return None
 
-def require_with_default(req, def):
-	try:
-		return req()
-	except:
-		if def is not None:
-			return def
-		raise
+def require_with_default(req, default):
+    try:
+        return req()
+    except:
+        if default is not None:
+            return default
+        raise
 `

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -13,6 +13,8 @@ def get_env(*args):
 def get_env_bool(*args):
     str = get_env(*args)
     if str is not None:
+        # NOTE: these values are taken from https://golang.org/src/strconv/atob.go?s=351:391#L1, which is what
+        # Terraform uses internally when parsing boolean values.
         if str in ["1", "t", "T", "true", "TRUE", "True"]:
             return True
         if str in ["0", "f", "F", "false", "FALSE", "False"]:

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -1,0 +1,194 @@
+package tfgen
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
+	"github.com/stretchr/testify/assert"
+)
+
+type defaultValueTest struct {
+	schema         schema.Schema
+	info           tfbridge.DefaultInfo
+	expectedNode   string
+	expectedGo     string
+	expectedPython string
+}
+
+var defaultTests = []defaultValueTest{
+	{
+		schema:         schema.Schema{Type: schema.TypeString},
+		expectedNode:   "undefined",
+		expectedGo:     "",
+		expectedPython: "",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeBool},
+		info:           tfbridge.DefaultInfo{Value: false},
+		expectedNode:   "false",
+		expectedGo:     "false",
+		expectedPython: "False",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeBool},
+		info:           tfbridge.DefaultInfo{Value: true},
+		expectedNode:   "true",
+		expectedGo:     "true",
+		expectedPython: "True",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeInt},
+		info:           tfbridge.DefaultInfo{Value: 0x4eedface},
+		expectedNode:   "1324219086",
+		expectedGo:     "1324219086",
+		expectedPython: "1324219086",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeInt},
+		info:           tfbridge.DefaultInfo{Value: uint(0xfeedface)},
+		expectedNode:   "4277009102",
+		expectedGo:     "4277009102",
+		expectedPython: "4277009102",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeFloat},
+		info:           tfbridge.DefaultInfo{Value: math.Pi},
+		expectedNode:   "3.141592653589793",
+		expectedGo:     "3.141592653589793",
+		expectedPython: "3.141592653589793",
+	},
+	{
+		schema:         schema.Schema{Type: schema.TypeString},
+		info:           tfbridge.DefaultInfo{Value: "foo"},
+		expectedNode:   `"foo"`,
+		expectedGo:     `"foo"`,
+		expectedPython: `"foo"`,
+	},
+}
+
+func Test_NodeDefaults(t *testing.T) {
+	for _, dvt := range defaultTests {
+		v := &variable{
+			name:   "v",
+			schema: &dvt.schema,
+			info:   &tfbridge.SchemaInfo{Default: &dvt.info},
+		}
+
+		actual := tsDefaultValue(v)
+		assert.Equal(t, dvt.expectedNode, actual)
+
+		getType := ""
+		switch dvt.schema.Type {
+		case schema.TypeBool:
+			getType = "Boolean"
+		case schema.TypeInt, schema.TypeFloat:
+			getType = "Number"
+		}
+
+		singleEnv := fmt.Sprintf(`utilities.getEnv%s("FOO")`, getType)
+		multiEnv := fmt.Sprintf(`utilities.getEnv%s("FOO", "BAR")`, getType)
+		if dvt.expectedNode != "undefined" {
+			singleEnv = fmt.Sprintf("(%s || %s)", singleEnv, dvt.expectedNode)
+			multiEnv = fmt.Sprintf("(%s || %s)", multiEnv, dvt.expectedNode)
+		}
+
+		v.info.Default.EnvVars = []string{"FOO"}
+		actual = tsDefaultValue(v)
+		assert.Equal(t, singleEnv, actual)
+
+		v.info.Default.EnvVars = []string{"FOO", "BAR"}
+		actual = tsDefaultValue(v)
+		assert.Equal(t, multiEnv, actual)
+	}
+}
+
+func Test_GoDefaults(t *testing.T) {
+	g := &goGenerator{}
+
+	testVar := func(v *variable, dvt defaultValueTest) {
+		v.info.Default.EnvVars = nil
+		actual := g.goDefaultValue(v)
+		assert.Equal(t, dvt.expectedGo, actual)
+
+		parser, outDefault := "nil", "\"\""
+		switch dvt.schema.Type {
+		case schema.TypeBool:
+			parser, outDefault = "parseEnvBool", "false"
+		case schema.TypeInt:
+			parser, outDefault = "parseEnvInt", "0"
+		case schema.TypeFloat:
+			parser, outDefault = "parseEnvFloat", "0.0"
+		}
+
+		defaultValue := dvt.expectedGo
+		if defaultValue == "" {
+			if v.out {
+				defaultValue = outDefault
+			} else {
+				defaultValue = "nil"
+			}
+		}
+
+		v.info.Default.EnvVars = []string{"FOO"}
+		expected := fmt.Sprintf(`getEnvOrDefault(%s, %s, "FOO")`, defaultValue, parser)
+		actual = g.goDefaultValue(v)
+		assert.Equal(t, expected, actual)
+
+		v.info.Default.EnvVars = []string{"FOO", "BAR"}
+		expected = fmt.Sprintf(`getEnvOrDefault(%s, %s, "FOO", "BAR")`, defaultValue, parser)
+		actual = g.goDefaultValue(v)
+		assert.Equal(t, expected, actual)
+	}
+
+	for _, dvt := range defaultTests {
+		v := &variable{
+			name:   "v",
+			schema: &dvt.schema,
+			info:   &tfbridge.SchemaInfo{Default: &dvt.info},
+		}
+
+		testVar(v, dvt)
+		v.out = true
+		testVar(v, dvt)
+	}
+}
+
+func Test_PythonDefaults(t *testing.T) {
+	for _, dvt := range defaultTests {
+		v := &variable{
+			name:   "v",
+			schema: &dvt.schema,
+			info:   &tfbridge.SchemaInfo{Default: &dvt.info},
+		}
+
+		actual := pyDefaultValue(v)
+		assert.Equal(t, dvt.expectedPython, actual)
+
+		envFunc := "utilities.get_env"
+		switch v.schema.Type {
+		case schema.TypeBool:
+			envFunc = "utilities.get_env_bool"
+		case schema.TypeInt:
+			envFunc = "utilities.get_env_int"
+		case schema.TypeFloat:
+			envFunc = "utilities.get_env_float"
+		}
+
+		singleEnv, multiEnv := fmt.Sprintf(`%s("FOO")`, envFunc), fmt.Sprintf(`%s("FOO", "BAR")`, envFunc)
+		if dvt.expectedPython != "" {
+			singleEnv = fmt.Sprintf("(%s or %s)", singleEnv, dvt.expectedPython)
+			multiEnv = fmt.Sprintf("(%s or %s)", multiEnv, dvt.expectedPython)
+		}
+
+		v.info.Default.EnvVars = []string{"FOO"}
+		actual = pyDefaultValue(v)
+		assert.Equal(t, singleEnv, actual)
+
+		v.info.Default.EnvVars = []string{"FOO", "BAR"}
+		actual = pyDefaultValue(v)
+		assert.Equal(t, multiEnv, actual)
+	}
+}

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -65,7 +65,7 @@ var defaultTests = []defaultValueTest{
 		info:           tfbridge.DefaultInfo{Value: "foo"},
 		expectedNode:   `"foo"`,
 		expectedGo:     `"foo"`,
-		expectedPython: `"foo"`,
+		expectedPython: `'foo'`,
 	},
 }
 
@@ -177,7 +177,7 @@ func Test_PythonDefaults(t *testing.T) {
 			envFunc = "utilities.get_env_float"
 		}
 
-		singleEnv, multiEnv := fmt.Sprintf(`%s("FOO")`, envFunc), fmt.Sprintf(`%s("FOO", "BAR")`, envFunc)
+		singleEnv, multiEnv := fmt.Sprintf(`%s('FOO')`, envFunc), fmt.Sprintf(`%s('FOO', 'BAR')`, envFunc)
 		if dvt.expectedPython != "" {
 			singleEnv = fmt.Sprintf("(%s or %s)", singleEnv, dvt.expectedPython)
 			multiEnv = fmt.Sprintf("(%s or %s)", multiEnv, dvt.expectedPython)


### PR DESCRIPTION
It is common for provider properties in Terraform to have defaults that
are pulled from environment variables or a literal value. These changes
add support for this scenario by adding an additional property to the
schema overlay containing envvars for default values. This property is
then used in concert with the existing literal default to generate
appropriate code for each language.