### PR TITLE
Save TF resource metadata in state.

### DIFF
--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -1,0 +1,181 @@
+package tfbridge
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func mustSet(data *schema.ResourceData, key string, value interface{}) {
+	err := data.Set(key, value)
+	if err != nil {
+		panic(err)
+	}
+}
+
+var testTFProvider = &schema.Provider{
+	Schema: map[string]*schema.Schema{
+		"config_value": &schema.Schema{},
+	},
+	ResourcesMap: map[string]*schema.Resource{
+		"example_resource": &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"nil_property_value":    {Type: schema.TypeMap},
+				"bool_property_value":   {Type: schema.TypeBool},
+				"number_property_value": {Type: schema.TypeInt},
+				"float_property_value":  {Type: schema.TypeFloat},
+				"string_property_value": {Type: schema.TypeString},
+				"array_property_value": {
+					Type: schema.TypeList,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"object_property_value": {Type: schema.TypeMap},
+				"nested_resources": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					// Embed a `*schema.Resource` to validate that type directed
+					// walk of the schema successfully walks inside Resources as well
+					// as Schemas.
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"configuration": {Type: schema.TypeMap},
+						},
+					},
+				},
+				"set_property_value": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"string_with_bad_interpolation": {Type: schema.TypeString},
+			},
+			SchemaVersion: 1,
+			MigrateState: func(v int, is *terraform.InstanceState, p interface{}) (*terraform.InstanceState, error) {
+				return is, nil
+			},
+			Create: func(data *schema.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Read: func(data *schema.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Update: func(data *schema.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Delete: func(data *schema.ResourceData, p interface{}) error {
+				return nil
+			},
+		},
+	},
+	DataSourcesMap: map[string]*schema.Resource{
+		"example_resource": &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"nil_property_value":    {Type: schema.TypeMap},
+				"bool_property_value":   {Type: schema.TypeBool},
+				"number_property_value": {Type: schema.TypeInt},
+				"float_property_value":  {Type: schema.TypeFloat},
+				"string_property_value": {Type: schema.TypeString},
+				"array_property_value": {
+					Type: schema.TypeList,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"object_property_value": {Type: schema.TypeMap},
+				"map_property_value":    {Type: schema.TypeMap},
+				"nested_resources": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					// Embed a `*schema.Resource` to validate that type directed
+					// walk of the schema successfully walks inside Resources as well
+					// as Schemas.
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"configuration": {Type: schema.TypeMap},
+						},
+					},
+				},
+				"set_property_value": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"string_with_bad_interpolation": {Type: schema.TypeString},
+			},
+			SchemaVersion: 1,
+			Read: func(data *schema.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+		},
+	},
+	ConfigureFunc: func(data *schema.ResourceData) (interface{}, error) {
+		return nil, nil
+	},
+}

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -14,10 +14,10 @@ func mustSet(data *schema.ResourceData, key string, value interface{}) {
 
 var testTFProvider = &schema.Provider{
 	Schema: map[string]*schema.Schema{
-		"config_value": &schema.Schema{},
+		"config_value": {},
 	},
 	ResourcesMap: map[string]*schema.Resource{
-		"example_resource": &schema.Resource{
+		"example_resource": {
 			Schema: map[string]*schema.Schema{
 				"nil_property_value":    {Type: schema.TypeMap},
 				"bool_property_value":   {Type: schema.TypeBool},
@@ -120,7 +120,7 @@ var testTFProvider = &schema.Provider{
 		},
 	},
 	DataSourcesMap: map[string]*schema.Resource{
-		"example_resource": &schema.Resource{
+		"example_resource": {
 			Schema: map[string]*schema.Schema{
 				"nil_property_value":    {Type: schema.TypeMap},
 				"bool_property_value":   {Type: schema.TypeBool},

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -15,10 +15,12 @@
 package tfbridge
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -448,6 +450,44 @@ func TestTerraformAttributes(t *testing.T) {
 	result, err = MakeTerraformAttributesFromInputs(sharedInputs, sharedSchema)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
+}
+
+// Test that meta-properties are correctly produced.
+func TestMetaProperties(t *testing.T) {
+	const resName = "example_resource"
+	res := testTFProvider.ResourcesMap["example_resource"]
+
+	info := &terraform.InstanceInfo{Type: resName}
+	state := &terraform.InstanceState{ID: "0", Attributes: map[string]string{}, Meta: map[string]interface{}{}}
+	read, err := testTFProvider.Refresh(info, state)
+	assert.NoError(t, err)
+	assert.NotNil(t, read)
+
+	props := MakeTerraformResult(read, res.Schema, nil)
+	assert.NotNil(t, props)
+
+	attrs, meta, err := MakeTerraformAttributes(res, props, res.Schema, nil, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, attrs)
+	assert.NotNil(t, meta)
+
+	assert.Equal(t, strconv.Itoa(res.SchemaVersion), meta["schema_version"])
+
+	state.Attributes, state.Meta = attrs, meta
+	read2, err := testTFProvider.Refresh(info, state)
+	assert.NoError(t, err)
+	assert.NotNil(t, read2)
+	assert.Equal(t, read, read2)
+
+	// Delete the resource's meta-property and ensure that we re-populate its schema version.
+	delete(props, metaKey)
+
+	attrs, meta, err = MakeTerraformAttributes(res, props, res.Schema, nil, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, attrs)
+	assert.NotNil(t, meta)
+
+	assert.Equal(t, strconv.Itoa(res.SchemaVersion), meta["schema_version"])
 }
 
 // Test that an unset list still generates a length attribute.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -488,6 +488,12 @@ func TestMetaProperties(t *testing.T) {
 	assert.NotNil(t, meta)
 
 	assert.Equal(t, strconv.Itoa(res.SchemaVersion), meta["schema_version"])
+
+	// Remove the resource's meta-attributes and ensure that we do not include them in the result.
+	read2.Meta = map[string]interface{}{}
+	props = MakeTerraformResult(read2, res.Schema, nil)
+	assert.NotNil(t, props)
+	assert.NotContains(t, props, metaKey)
 }
 
 // Test that an unset list still generates a length attribute.


### PR DESCRIPTION
These changes add support for storing a Terraform resource's metadata
alongside its attributes in its Pulumi state. The metadata is stored as
a Pulumi property map under the key `__meta`, which should not be used
as a property name by a Terraform resource. Notably, this metadata
includes the `schema_version` property, which is used by the TF schema
code to detect the need for schema migration.

If a resource has no metadata but its schema's `SchemaVersion` is
non-zero, we inject that version into its metadata before interacting
with the TF provider. This ensures that TF always sees a valid schema
version when one is required.

This is necessary to address #226.