### PR TITLE
Do not populate defaults for deprecated properties.

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -83,6 +83,9 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 			if _, conflicts := conflictsWith[name]; conflicts {
 				continue
 			}
+			if sch, ok := tfs[name]; ok && sch.Deprecated != "" && !sch.Required {
+				continue
+			}
 
 			if _, has := result[name]; !has && info.HasDefault() {
 				// If we already have a default value from a previous version of this resource, use that instead.
@@ -115,6 +118,9 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 		// Next, populate defaults from the Terraform schema.
 		for name, sch := range tfs {
+			if sch.Deprecated != "" && !sch.Required {
+				continue
+			}
 			if _, conflicts := conflictsWith[name]; conflicts {
 				continue
 			}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -530,7 +530,7 @@ func TestDefaults(t *testing.T) {
 	//     - mmm: old default "OLM", PS default "PSM", no input => "OLM"
 	//     - www: old default "OLW", deprecated, required, no input -> "OLW"
 	//     - xxx: old default "OLX", deprecated, no input => nothing
-	//     - yyy: TF default "TLY", deprecared, no input => nothing
+	//     - yyy: TF default "TLY", deprecated, no input => nothing
 	asset, err := resource.NewTextAsset("hello")
 	assert.Nil(t, err)
 	assets := make(AssetTable)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -528,6 +528,7 @@ func TestDefaults(t *testing.T) {
 	//     - jjj string: old input "OLJ", no defaults, no input => no merged input
 	//     - lll: old default "OLL", TF default "TFL", no input => "OLL"
 	//     - mmm: old default "OLM", PS default "PSM", no input => "OLM"
+	//     - www: old default "OLW", deprecated, required, no input -> "OLW"
 	//     - xxx: old default "OLX", deprecated, no input => nothing
 	//     - yyy: TF default "TLY", deprecared, no input => nothing
 	asset, err := resource.NewTextAsset("hello")
@@ -544,6 +545,7 @@ func TestDefaults(t *testing.T) {
 		"jjj": {Type: schema.TypeString},
 		"lll": {Type: schema.TypeString, Default: "TFL"},
 		"mmm": {Type: schema.TypeString},
+		"www": {Type: schema.TypeString, Deprecated: "deprecated", Required: true},
 		"xxx": {Type: schema.TypeString, Deprecated: "deprecated", Optional: true},
 		"yyy": {Type: schema.TypeString, Default: "TLY", Deprecated: "deprecated", Optional: true},
 		"zzz": {Type: schema.TypeString},
@@ -557,6 +559,7 @@ func TestDefaults(t *testing.T) {
 		"hhh": {Default: &DefaultInfo{Value: "PSH"}},
 		"iii": {Default: &DefaultInfo{Value: "PSI"}},
 		"mmm": {Default: &DefaultInfo{Value: "PSM"}},
+		"www": {Default: &DefaultInfo{Value: "PSW"}},
 		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
 	}
 	olds := resource.PropertyMap{
@@ -564,6 +567,8 @@ func TestDefaults(t *testing.T) {
 		"jjj": resource.NewStringProperty("OLJ"),
 		"lll": resource.NewStringProperty("OLL"),
 		"mmm": resource.NewStringProperty("OLM"),
+		"www": resource.NewStringProperty("OLW"),
+		"xxx": resource.NewStringProperty("OLX"),
 	}
 	props := resource.PropertyMap{
 		"bbb": resource.NewStringProperty("BBB"),
@@ -592,6 +597,7 @@ func TestDefaults(t *testing.T) {
 		"iii": "OLI",
 		"lll": "OLL",
 		"mmm": "OLM",
+		"www": "OLW",
 		"zzz": asset,
 	}), outputs)
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -528,6 +528,8 @@ func TestDefaults(t *testing.T) {
 	//     - jjj string: old input "OLJ", no defaults, no input => no merged input
 	//     - lll: old default "OLL", TF default "TFL", no input => "OLL"
 	//     - mmm: old default "OLM", PS default "PSM", no input => "OLM"
+	//     - xxx: old default "OLX", deprecated, no input => nothing
+	//     - yyy: TF default "TLY", deprecared, no input => nothing
 	asset, err := resource.NewTextAsset("hello")
 	assert.Nil(t, err)
 	assets := make(AssetTable)
@@ -542,6 +544,8 @@ func TestDefaults(t *testing.T) {
 		"jjj": {Type: schema.TypeString},
 		"lll": {Type: schema.TypeString, Default: "TFL"},
 		"mmm": {Type: schema.TypeString},
+		"xxx": {Type: schema.TypeString, Deprecated: "deprecated", Optional: true},
+		"yyy": {Type: schema.TypeString, Default: "TLY", Deprecated: "deprecated", Optional: true},
 		"zzz": {Type: schema.TypeString},
 	}
 	ps := map[string]*SchemaInfo{


### PR DESCRIPTION
Just what it says on the tin.

Fixes #196.