### PR TITLE
Support timeouts in TF metadata.

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -401,8 +401,10 @@ func MakeTerraformOutput(v interface{},
 	switch val.Kind() {
 	case reflect.Bool:
 		return resource.NewBoolProperty(val.Bool())
-	case reflect.Int:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return resource.NewNumberProperty(float64(val.Int()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return resource.NewNumberProperty(float64(val.Uint()))
 	case reflect.Float64:
 		return resource.NewNumberProperty(val.Float())
 	case reflect.String:

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -1,6 +1,8 @@
 package tfbridge
 
 import (
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -10,6 +12,10 @@ func mustSet(data *schema.ResourceData, key string, value interface{}) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func timeout(d time.Duration) *time.Duration {
+	return &d
 }
 
 var testTFProvider = &schema.Provider{
@@ -52,6 +58,7 @@ var testTFProvider = &schema.Provider{
 				return is, nil
 			},
 			Create: func(data *schema.ResourceData, p interface{}) error {
+				data.SetId("0")
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -116,6 +123,9 @@ var testTFProvider = &schema.Provider{
 			},
 			Delete: func(data *schema.ResourceData, p interface{}) error {
 				return nil
+			},
+			Timeouts: &schema.ResourceTimeout{
+				Create: timeout(time.Second * 120),
 			},
 		},
 	},

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -506,6 +506,25 @@ func TestMetaProperties(t *testing.T) {
 	props = MakeTerraformResult(read2, res.Schema, nil)
 	assert.NotNil(t, props)
 	assert.NotContains(t, props, metaKey)
+
+	// Ensure that timeouts are populated and preserved.
+	state.ID = ""
+	cfg, err := config.NewRawConfig(map[string]interface{}{})
+	assert.NoError(t, err)
+	diff, err := testTFProvider.Diff(info, state, terraform.NewResourceConfig(cfg))
+	assert.NoError(t, err)
+	create, err := testTFProvider.Apply(info, state, diff)
+	assert.NoError(t, err)
+
+	props = MakeTerraformResult(create, res.Schema, nil)
+	assert.NotNil(t, props)
+
+	attrs, meta, err = MakeTerraformAttributes(res, props, res.Schema, nil, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, attrs)
+	assert.NotNil(t, meta)
+
+	assert.Contains(t, meta, schema.TimeoutKey)
 }
 
 // Test that an unset list still generates a length attribute.


### PR DESCRIPTION
Now that we are recording TF metadata, we need to handle custom
timeouts. These are encoded as int64 values in the metadata bag.

Fixes #151.