### PR TITLE
Fix envvar default reads in tfbridge.

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -115,14 +115,16 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 								}
 							}
 						case schema.TypeInt:
-							v = 0
+							v = int(0)
 							if str != "" {
-								if v, err = strconv.ParseInt(str, 0, 0); err != nil {
+								iv, err := strconv.ParseInt(str, 0, 0)
+								if err != nil {
 									return nil, err
 								}
+								v = int(iv)
 							}
 						case schema.TypeFloat:
-							v = 0.0
+							v = float64(0.0)
 							if str != "" {
 								if v, err = strconv.ParseFloat(str, 64); err != nil {
 									return nil, err

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -84,7 +84,8 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 			if _, conflicts := conflictsWith[name]; conflicts {
 				continue
 			}
-			if sch, ok := tfs[name]; ok && sch.Deprecated != "" && !sch.Required {
+			sch := tfs[name]
+			if sch != nil && sch.Deprecated != "" && !sch.Required {
 				continue
 			}
 
@@ -100,9 +101,43 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 					result[name] = v
 					glog.V(9).Infof("Created Terraform input: %v = %v (old default)", key, old)
 				} else if envVars := info.Default.EnvVars; len(envVars) != 0 {
-					result[name] = schema.MultiEnvDefaultFunc(envVars, info.Default.Value)
+					v, err := schema.MultiEnvDefaultFunc(envVars, info.Default.Value)()
+					if err != nil {
+						return nil, err
+					}
+					if str, ok := v.(string); ok && sch != nil {
+						switch sch.Type {
+						case schema.TypeBool:
+							v = false
+							if str != "" {
+								if v, err = strconv.ParseBool(str); err != nil {
+									return nil, err
+								}
+							}
+						case schema.TypeInt:
+							v = 0
+							if str != "" {
+								if v, err = strconv.ParseInt(str, 0, 0); err != nil {
+									return nil, err
+								}
+							}
+						case schema.TypeFloat:
+							v = 0.0
+							if str != "" {
+								if v, err = strconv.ParseFloat(str, 64); err != nil {
+									return nil, err
+								}
+							}
+						case schema.TypeString:
+							// nothing to do
+						default:
+							return nil, errors.Errorf("unknown type for default value: %s", sch.Type)
+						}
+					}
+					if v != nil {
+						result[name] = v
+					}
 					glog.V(9).Infof("Created Terraform input: %v = %v (default from env vars)", name, result[name])
-
 				} else if info.Default.Value != nil {
 					result[name] = info.Default.Value
 					glog.V(9).Infof("Created Terraform input: %v = %v (default)", name, result[name])

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -15,6 +15,7 @@
 package tfbridge
 
 import (
+	"os"
 	"strconv"
 	"testing"
 
@@ -559,9 +560,13 @@ func TestDefaults(t *testing.T) {
 	//     - jjj string: old input "OLJ", no defaults, no input => no merged input
 	//     - lll: old default "OLL", TF default "TFL", no input => "OLL"
 	//     - mmm: old default "OLM", PS default "PSM", no input => "OLM"
+	//     - uuu: PS default "PSU", envvars w/o valiues => "PSU"
+	//     - vvv: PS default 42, envvars with values => 1337
 	//     - www: old default "OLW", deprecated, required, no input -> "OLW"
 	//     - xxx: old default "OLX", deprecated, no input => nothing
 	//     - yyy: TF default "TLY", deprecated, no input => nothing
+	err := os.Setenv("PTFV2", "1337")
+	assert.Nil(t, err)
 	asset, err := resource.NewTextAsset("hello")
 	assert.Nil(t, err)
 	assets := make(AssetTable)
@@ -576,6 +581,8 @@ func TestDefaults(t *testing.T) {
 		"jjj": {Type: schema.TypeString},
 		"lll": {Type: schema.TypeString, Default: "TFL"},
 		"mmm": {Type: schema.TypeString},
+		"uuu": {Type: schema.TypeString},
+		"vvv": {Type: schema.TypeInt},
 		"www": {Type: schema.TypeString, Deprecated: "deprecated", Required: true},
 		"xxx": {Type: schema.TypeString, Deprecated: "deprecated", Optional: true},
 		"yyy": {Type: schema.TypeString, Default: "TLY", Deprecated: "deprecated", Optional: true},
@@ -590,6 +597,8 @@ func TestDefaults(t *testing.T) {
 		"hhh": {Default: &DefaultInfo{Value: "PSH"}},
 		"iii": {Default: &DefaultInfo{Value: "PSI"}},
 		"mmm": {Default: &DefaultInfo{Value: "PSM"}},
+		"uuu": {Default: &DefaultInfo{Value: "PSU", EnvVars: []string{"PTFU", "PTFU2"}}},
+		"vvv": {Default: &DefaultInfo{Value: 42, EnvVars: []string{"PTFV", "PTFV2"}}},
 		"www": {Default: &DefaultInfo{Value: "PSW"}},
 		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
 	}
@@ -628,6 +637,8 @@ func TestDefaults(t *testing.T) {
 		"iii": "OLI",
 		"lll": "OLL",
 		"mmm": "OLM",
+		"uuu": "PSU",
+		"vvv": 1337,
 		"www": "OLW",
 		"zzz": asset,
 	}), outputs)


### PR DESCRIPTION
- MultiEnvDefaultFunc returns a function that must be invoked to produce
  a default value. We were not invoking the function.
- The return value of the default-producing function may be a string
  that needs to be converted to an appropriate primitive type.