### PR TITLE
Marshal/unmarshal complex config as JSON.

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1,0 +1,121 @@
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertStringToPropertyValue(t *testing.T) {
+	type testcase struct {
+		str      string
+		typ      schema.ValueType
+		expected interface{}
+	}
+
+	cases := []testcase{
+		{
+			typ:      schema.TypeBool,
+			expected: false,
+		},
+		{
+			str:      "false",
+			typ:      schema.TypeBool,
+			expected: false,
+		},
+		{
+			str:      "true",
+			typ:      schema.TypeBool,
+			expected: true,
+		},
+		{
+			str: "root",
+			typ: schema.TypeBool,
+		},
+
+		{
+			typ:      schema.TypeString,
+			expected: "",
+		},
+		{
+			str:      "stringP",
+			typ:      schema.TypeString,
+			expected: "stringP",
+		},
+
+		{
+			typ:      schema.TypeInt,
+			expected: 0,
+		},
+		{
+			str:      "42",
+			typ:      schema.TypeInt,
+			expected: 42,
+		},
+		{
+			str: "root",
+			typ: schema.TypeInt,
+		},
+
+		{
+			typ:      schema.TypeFloat,
+			expected: 0,
+		},
+		{
+			str:      "42",
+			typ:      schema.TypeFloat,
+			expected: 42,
+		},
+		{
+			str: "root",
+			typ: schema.TypeFloat,
+		},
+
+		{
+			typ:      schema.TypeList,
+			expected: []interface{}{},
+		},
+		{
+			str:      "[ \"foo\", \"bar\" ]",
+			typ:      schema.TypeList,
+			expected: []interface{}{"foo", "bar"},
+		},
+
+		{
+			typ:      schema.TypeSet,
+			expected: []interface{}{},
+		},
+		{
+			str:      "[ \"foo\", \"bar\" ]",
+			typ:      schema.TypeSet,
+			expected: []interface{}{"foo", "bar"},
+		},
+
+		{
+			typ:      schema.TypeMap,
+			expected: map[string]interface{}{},
+		},
+		{
+			str: "{ \"foo\": { \"bar\": 42 }, \"baz\": [ true ] }",
+			typ: schema.TypeMap,
+			expected: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": 42,
+				},
+				"baz": []interface{}{
+					true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		v, err := convertStringToPropertyValue(c.str, c.typ)
+		assert.Equal(t, resource.NewPropertyValue(c.expected), v)
+		if c.expected == nil {
+			assert.Error(t, err)
+		}
+	}
+}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -192,7 +192,7 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 	if glog.V(5) {
 		for k, v := range result {
-			glog.V(5).Infof("Terraform input %v = %v", k, v)
+			glog.V(5).Infof("Terraform input %v = %#v", k, v)
 		}
 	}
 

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -568,6 +568,12 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		if defaultValue := tsDefaultValue(prop); defaultValue != "undefined" {
 			arg = fmt.Sprintf("(%s) || %s", arg, defaultValue)
 		}
+
+		// provider properties must be marshaled as JSON strings.
+		if res.IsProvider() && prop.schema != nil && prop.schema.Type != schema.TypeString {
+			arg = fmt.Sprintf("JSON.stringify(%s)", arg)
+		}
+
 		w.Writefmtln(`            inputs["%s"] = %s;`, prop.name, arg)
 	}
 	for _, prop := range res.outprops {


### PR DESCRIPTION
Terraform providers accept complex (i.e. non-string) config. As it
stands, we require that all provider configuration values are strings,
which causes an unfortunate inability to use these complex configuration
values. These changes enable the use of complex configuration by
serializing and deserializing complex config values using JSON.

Note that this creates a compat issue for future changes to enable
actual rich configuration in the RPC interface; such a future change
will need to accept rich values _or_ strings for top-level properties.

Fixes #48.