### PR TITLE
Fix the token for provider resources.

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -474,7 +474,7 @@ func (g *generator) gatherProvider() (*resourceType, error) {
 		cfg = map[string]*schema.Schema{}
 	}
 	info := &tfbridge.ResourceInfo{
-		Tok:    tokens.Type(g.info.Name),
+		Tok:    tokens.Type(g.pkg),
 		Fields: g.info.Config,
 	}
 	_, res, err := g.gatherResource("", &schema.Resource{Schema: cfg}, info, true)


### PR DESCRIPTION
The token must be the same as the Pulumi package name, not the TF
provider name.