### PR TITLE
Relax asset reflection.

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -451,15 +451,8 @@ func MakeTerraformOutput(v interface{},
 			return asset
 		}
 
-		// we might not have the asset value if this was something computed. in that
-		// case just return an appropriate sentinel indicating that was the case.
-
-		t, ok := v.(string)
-		contract.Assert(ok)
-		contract.Assert(t == config.UnknownVariableValue)
-
-		return resource.NewComputedProperty(
-			resource.Computed{Element: resource.NewStringProperty("")})
+		// If we don't have the value, it is possible that the user supplied a value that was not an asset. Let the
+		// normal marshalling logic handle it in that case.
 	}
 
 	if v == nil {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -695,9 +695,10 @@ func TestInvalidAsset(t *testing.T) {
 	}
 	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
 	assert.NoError(t, err)
-	assert.Panics(t, func() {
-		MakeTerraformOutputs(inputs, tfs, ps, assets, false)
-	})
+	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false)
+	assert.Equal(t, resource.PropertyMap{
+		"zzz": resource.NewStringProperty("invalid"),
+	}, outputs)
 }
 
 func boolPointer(b bool) *bool {


### PR DESCRIPTION
The TF <-> Pulumi marshaller attempts to turn outputs that corresponds
to inputs that were assets back in to the original asset value so that
the engine is able to provide better diffs. The logic it used to do this
was overly strict, and required that all properties that had asset
mappings have asset values. These changes relax that condition s.t.
values that are not assets are passed through as-is.

Fixes #139.