### PR TITLE
Enable "destination overlays".

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -115,8 +115,9 @@ type PulumiResource struct {
 // permits extra files to be included from the overlays/ directory when building up packs/.  This allows augmented
 // code-generation for convenient things like helper functions, modules, and gradual typing.
 type OverlayInfo struct {
-	Files   []string                // additional files to include in the index file.
-	Modules map[string]*OverlayInfo // extra modules to inject into the structure.
+	Files     []string                // additional files to include in the index file.
+	DestFiles []string                // like Files, but the overlays must already exist in the destination.
+	Modules   map[string]*OverlayInfo // extra modules to inject into the structure.
 }
 
 // JavaScriptInfo contains optional overlay information for Python code-generation.

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -297,6 +297,7 @@ type overlayFile struct {
 
 func (of *overlayFile) Name() string { return of.name }
 func (of *overlayFile) Doc() string  { return "" }
+func (of *overlayFile) Copy() bool   { return of.src != "" }
 
 // plainOldType is any simple type definition that doesn't correspond to Pulumi CustomResources.  Note that this is not
 // a legal top-level module definition; instead, this type is embedded within others (see resourceType and Func).
@@ -799,6 +800,10 @@ func (g *generator) gatherOverlays() (moduleMap, error) {
 				name: file,
 				src:  filepath.Join(g.overlaysDir, file),
 			})
+		}
+		for _, file := range overlay.DestFiles {
+			root := modules.ensureModule("")
+			root.addMember(&overlayFile{name: file})
 		}
 
 		// Now add all overlays that are modules.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -16,6 +16,7 @@ package tfgen
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -602,7 +603,11 @@ func (g *goGenerator) emitOverlay(mod *module, overlay *overlayFile) error {
 	// Copy the file from the overlays directory to the destination.
 	dir := g.moduleDir(mod)
 	dst := filepath.Join(dir, overlay.name)
-	return copyFile(overlay.src, dst)
+	if overlay.Copy() {
+		return copyFile(overlay.src, dst)
+	}
+	_, err := os.Stat(dst)
+	return err
 }
 
 // emitPackageMetadata generates all the non-code metadata required by a Pulumi package.

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -17,6 +17,7 @@ package tfgen
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -675,8 +676,14 @@ func (g *nodeJSGenerator) emitOverlay(mod *module, overlay *overlayFile) (string
 	// Copy the file from the overlays directory to the destination.
 	dir := g.moduleDir(mod)
 	dst := filepath.Join(dir, overlay.name)
-	if err := copyFile(overlay.src, dst); err != nil {
-		return "", err
+	if overlay.Copy() {
+		if err := copyFile(overlay.src, dst); err != nil {
+			return "", err
+		}
+	} else {
+		if _, err := os.Stat(dst); err != nil {
+			return "", err
+		}
 	}
 
 	// And then export the overlay's contents from the index.

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -16,6 +16,7 @@ package tfgen
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -577,8 +578,14 @@ func (g *pythonGenerator) emitOverlay(mod *module, overlay *overlayFile) (string
 	// Copy the file from the overlays directory to the destination.
 	dir := g.moduleDir(mod)
 	dst := filepath.Join(dir, overlay.name)
-	if err := copyFile(overlay.src, dst); err != nil {
-		return "", err
+	if overlay.Copy() {
+		if err := copyFile(overlay.src, dst); err != nil {
+			return "", err
+		}
+	} else {
+		if _, err := os.Stat(dst); err != nil {
+			return "", err
+		}
 	}
 
 	// And then export the overlay's contents from the index.


### PR DESCRIPTION
A destination overlay is an overlay that is expected to be present in
the destination directory a priori. Like a normal overlay, it is added
to its module's index.ts.