### PR TITLE
[WIP] Add node.js module containing Terraform interpolation functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TESTPARALLELISM = 10
 build::
 	go build ${PROJECT}/pkg/tfgen
 	go build ${PROJECT}/pkg/tfbridge
+	cd sdk/nodejs && npm install && npm run build
 
 lint::
 	golangci-lint run
@@ -18,6 +19,7 @@ test_fast::
 
 test_all::
 	$(GO_TEST) ${GOPKGS}
+	cd sdk/nodejs && npm run test
 
 .PHONY: publish_packages
 	$(call STEP_MESSAGE)

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,13 @@ test_all::
 	cd sdk/nodejs && npm run test
 
 .PHONY: publish_packages
+publish_packages::
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: all
+travis_push: all publish_packages
 travis_pull_request: all
 travis_api: all

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ lint::
 
 test_fast::
 	$(GO_TEST_FAST) ${GOPKGS}
+	cd 
 
 test_all::
 	$(GO_TEST) ${GOPKGS}
+
+.PHONY: publish_packages
+	$(call STEP_MESSAGE)
+	./scripts/publish_packages.sh
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# publish.sh builds and publishes a release.
+set -o nounset -o errexit -o pipefail
+ROOT=$(dirname $0)/..
+
+echo "Publishing NPM packages to NPMjs.com:"
+
+# For each package, first create the package.json to publish.  This must be different than the one we use for
+# development and testing the SDK, since we use symlinking for those workflows.  Namely, we must promote the SDK
+# dependencies from peerDependencies that are resolved via those links, to real installable dependencies.
+publish() {
+    node $(dirname $0)/promote.js ${@:2} < \
+        ${ROOT}/sdk/nodejs/$1/bin/package.json > \
+        ${ROOT}/sdk/nodejs/$1/bin/package.json.publish
+    pushd ${ROOT}/sdk/nodejs/$1/bin
+    mv package.json package.json.dev
+    mv package.json.publish package.json
+
+    NPM_TAG="dev"
+
+    # We use the "features/" prefix on branches that we want to build and publish for doing
+    # cross repo work. But in this case, we don't want to publish over "dev", since the bits
+    # could be totally busted and the dev tag tracks master.
+    if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
+        NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
+    fi
+
+    # If the package doesn't have a pre-release tag, use the tag of latest instead of
+    # dev. NPM uses this tag as the default version to add, so we want it to mean
+    # the newest released version.
+    if [[ $(jq -r .version < package.json) != *-* ]]; then
+        NPM_TAG="latest"
+    fi
+
+    # Now, perform the publish.
+    npm publish -tag ${NPM_TAG}
+    npm info 2>/dev/null
+
+    # And finally restore the original package.json.
+    mv package.json package.json.publish
+    mv package.json.dev package.json
+    popd
+}
+
+publish terraform

--- a/sdk/nodejs/.gitignore
+++ b/sdk/nodejs/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/.idea/

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,0 +1,9 @@
+# Pulumi Interpolation Functions for Terraform Users
+
+This package contains many of the built-in interpolation functions from
+[Terraform][tf], implemented in Node.js to allow easy migration from Terraform
+to [Pulumi][pulumi].
+
+
+[tf]: https://terraform.io
+[pulumi]: https://pulumi.io

--- a/sdk/nodejs/lib/index.d.ts
+++ b/sdk/nodejs/lib/index.d.ts
@@ -1,0 +1,173 @@
+/**
+ * abs returns the absolute value of a given number. See also the signum function.
+ *
+ * Examples:
+ *     - `abs(1)` returns `1`
+ *     - `abs(-1)` returns `1`
+ *     - `abs(-3.14)` returns `3.14`
+ *
+ * @param input number for which to return the absolute value
+ */
+export declare function abs(input: number): number;
+/**
+ * basename returns the last element of a path.
+ *
+ * @param path the full path
+ */
+export declare function basename(path: string): string;
+/**
+ * base64decode decodes base64-encoded data and returns the utf-8-encoded string. An
+ * error is thrown if the argument is not valid base64 data.
+ *
+ * @param encoded valid base64-encoded string
+ */
+export declare function base64decode(encoded: string): string;
+/**
+ * base64encode returns a base64-encoded version of the given string.
+ *
+ * @param unencoded the string to encode
+ */
+export declare function base64encode(unencoded: string): string;
+/**
+ * base64gzip compresses the given string with gzip and then returns the resulting data as
+ * a base64-encoded string.
+ *
+ * @param unencoded the string to compress and encode
+ */
+export declare function base64gzip(unencoded: string): string;
+export declare function base64sha256(input: string): string;
+export declare function base64sha512(input: string): string;
+/**
+ * bcrypt returns the Blowfish encrypted hash of the string at the given cost. A default
+ * cost of 10 will be used if not provided.
+ *
+ * @param password password to encrypt
+ * @param cost defaults to 10 if unset
+ */
+export declare function bcrypt(password: string, cost?: number): string;
+/**
+ * ceil returns the smallest integer value greater than or equal to the argument.
+ *
+ * @param input number of which to find the ceiling
+ */
+export declare function ceil(input: number): number;
+export declare function chomp(input: string): string;
+/**
+ * chunklist returns a list items chunked by size. For example:
+ *
+ * - chunklist(["id1", "id2", "id3"], 1) returns [["id1"], ["id2"], ["id3"]]
+ * - chunklist(["id1", "id2", "id3"], 2) returns [["id1", "id2"], ["id3"]]
+ *
+ * @param input the list to chunk
+ * @param size the size of each chunk
+ */
+export declare function chunklist<T>(input: T[], size: number): T[][];
+/**
+ * coalesce returns the first non-empty string from the given arguments, or an empty string if all
+ * of the arguments are undefined.
+ *
+ * @param first a potentially non-empty stringj
+ * @param others other potentially non-empty values
+ */
+export declare function coalesce(first: string | undefined, ...others: (string | undefined)[]): string;
+/**
+ * coalescelist returns the first non-empty list from the given arguments, or an empty list if
+ * all of the arguments are undefined or empty lists.
+ *
+ * @param first a potentially non-empty array
+ * @param others other potentially non-empty arrays
+ */
+export declare function coalescelist<T>(first: T[] | undefined, ...others: (T[] | undefined)[]): T[];
+/**
+ * compact removes empty string elements from a list. This can be useful in some cases,
+ * for example when passing joined lists as module variables or when parsing module outputs.
+ *
+ * @param input a string array from which to remove empty values
+ */
+export declare function compact(input: string[]): string[];
+/**
+ * concat combines two or more lists into a single list.
+ *
+ * @param first the first list
+ * @param others other lists
+ */
+export declare function concat<T>(first: T[], ...others: T[][]): T[];
+/**
+ * contains returns true if an array contains the given element and returns false otherwise
+ * @param haystack the array in which to search
+ * @param needle the element for which to search
+ */
+export declare function contains<T>(haystack: T[], needle: T): boolean;
+export declare function dirname(path: string): string;
+export declare function distinct(input: string[]): string[];
+export declare function element(inputList: string[], elementIndex: number): string;
+export declare function file(path: string): string;
+export declare function floor(input: number): number;
+/**
+ * format returns a string formatted using the given base string and arguments.
+ *
+ * *NOTE*: This is not a 1-1 map of the Terraform `format` function, since it uses the
+ * node.js `sprintf-js` library instead of the implementation of `fmt.Sprintf` in the Go
+ * standard library. However, it is reasonably close in semantic and will work for a
+ * large number of simple use cases.
+ *
+ * @param formatString a format string
+ * @param args the arguments to be applied to the format string
+ */
+export declare function format(formatString: string, ...args: any[]): string;
+export declare function formatlist(formatString: string, ...args: any[][]): string[];
+export declare function indent(indentSize: number, stringToIndent: string): string;
+export declare function index<T>(haystack: T[], needle: T): number;
+export declare function join(separator: string, ...strings: string[][]): string;
+export declare function jsonencode(input: any): string;
+export declare function keys(input: {
+    [k: string]: any;
+}): string[];
+export declare function length(input: string | any[] | {
+    [k: string]: any;
+}): number;
+export declare function list<T>(...elements: T[]): T[];
+export declare function log(x: number, base: number): number;
+export declare function lookup<T>(inputMap: {
+    [k: string]: T;
+}, key: string, defaultValue?: T): T;
+export declare function lower(input: string): string;
+export declare function map(...keyValuePairs: any[]): {
+    [k: string]: any;
+};
+export declare function max(...numbers: number[]): number;
+export declare function merge(...maps: {
+    [k: string]: any;
+}[]): {
+    [k: string]: any;
+};
+export declare function min(...numbers: number[]): number;
+export declare function md5(input: string): string;
+export declare function pathexpand(path: string): string;
+export declare function pow(base: number, exponent: number): number;
+export declare function replace(input: string, toMatch: string | RegExp, replacement: string): string;
+export declare function sha1(input: string): string;
+export declare function sha256(input: string): string;
+export declare function sha512(input: string): string;
+export declare function signum(input: number): number;
+export declare function slice(input: string[], start: number, end: number): string[];
+export declare function sort(input: string[]): string[];
+export declare function split(separator: string, input: string): string[];
+export declare function substr(input: string, offset: number, len: number): string;
+export declare function transpose(inputMap: {
+    [k: string]: string[];
+}): {
+    [k: string]: string[];
+};
+export declare function timestamp(): string;
+export declare function title(input: string): string;
+export declare function trimspace(input: string): string;
+export declare function upper(input: string): string;
+export declare function uuid(): string;
+export declare function urlencode(input: string): string;
+export declare function values<T>(inputMap: {
+    [k: string]: T;
+}): T[];
+export declare function zipmap<T>(keyList: string[], valueList: T[]): {
+    [k: string]: T;
+};

--- a/sdk/nodejs/lib/index.js
+++ b/sdk/nodejs/lib/index.js
@@ -1,0 +1,514 @@
+"use strict";
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const bcryptjs = require("bcryptjs");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const Path = require("path");
+const sprintf_js_1 = require("sprintf-js");
+const uuid_1 = require("uuid");
+const zlib_1 = require("zlib");
+const zlib = require("zlib");
+const titleCase = require("title-case");
+/**
+ * abs returns the absolute value of a given number. See also the signum function.
+ *
+ * Examples:
+ *     - `abs(1)` returns `1`
+ *     - `abs(-1)` returns `1`
+ *     - `abs(-3.14)` returns `3.14`
+ *
+ * @param input number for which to return the absolute value
+ */
+function abs(input) {
+    return Math.abs(input);
+}
+exports.abs = abs;
+/**
+ * basename returns the last element of a path.
+ *
+ * @param path the full path
+ */
+function basename(path) {
+    return Path.win32.basename(path);
+}
+exports.basename = basename;
+/**
+ * base64decode decodes base64-encoded data and returns the utf-8-encoded string. An
+ * error is thrown if the argument is not valid base64 data.
+ *
+ * @param encoded valid base64-encoded string
+ */
+function base64decode(encoded) {
+    const decoded = Buffer.from(encoded, "base64").toString("utf-8");
+    if (decoded.length !== ((encoded.length / 4) * 3)) {
+        throw new Error("failed to decode base64 data");
+    }
+    return decoded;
+}
+exports.base64decode = base64decode;
+/**
+ * base64encode returns a base64-encoded version of the given string.
+ *
+ * @param unencoded the string to encode
+ */
+function base64encode(unencoded) {
+    return Buffer.from(unencoded).toString("base64");
+}
+exports.base64encode = base64encode;
+/**
+ * base64gzip compresses the given string with gzip and then returns the resulting data as
+ * a base64-encoded string.
+ *
+ * @param unencoded the string to compress and encode
+ */
+function base64gzip(unencoded) {
+    const compressed = zlib_1.gzipSync(unencoded, {
+        level: zlib.constants.Z_DEFAULT_COMPRESSION,
+    });
+    return compressed.toString("base64");
+}
+exports.base64gzip = base64gzip;
+function base64sha256(input) {
+    const hash = crypto.createHash("sha256");
+    hash.update(input);
+    return hash.digest().toString("base64");
+}
+exports.base64sha256 = base64sha256;
+function base64sha512(input) {
+    const hash = crypto.createHash("sha512");
+    hash.update(input);
+    return hash.digest().toString("base64");
+}
+exports.base64sha512 = base64sha512;
+/**
+ * bcrypt returns the Blowfish encrypted hash of the string at the given cost. A default
+ * cost of 10 will be used if not provided.
+ *
+ * @param password password to encrypt
+ * @param cost defaults to 10 if unset
+ */
+function bcrypt(password, cost) {
+    return bcryptjs.hashSync(password, cost || 10);
+}
+exports.bcrypt = bcrypt;
+/**
+ * ceil returns the smallest integer value greater than or equal to the argument.
+ *
+ * @param input number of which to find the ceiling
+ */
+function ceil(input) {
+    return Math.ceil(input);
+}
+exports.ceil = ceil;
+function chomp(input) {
+    return input.replace(/[\r\n]+$/, "");
+}
+exports.chomp = chomp;
+/**
+ * chunklist returns a list items chunked by size. For example:
+ *
+ * - chunklist(["id1", "id2", "id3"], 1) returns [["id1"], ["id2"], ["id3"]]
+ * - chunklist(["id1", "id2", "id3"], 2) returns [["id1", "id2"], ["id3"]]
+ *
+ * @param input the list to chunk
+ * @param size the size of each chunk
+ */
+function chunklist(input, size) {
+    const temp = input.slice(0);
+    const results = [];
+    while (temp.length) {
+        results.push(temp.splice(0, size));
+    }
+    return results;
+}
+exports.chunklist = chunklist;
+/**
+ * coalesce returns the first non-empty string from the given arguments, or an empty string if all
+ * of the arguments are undefined.
+ *
+ * @param first a potentially non-empty stringj
+ * @param others other potentially non-empty values
+ */
+function coalesce(first, ...others) {
+    if (first !== undefined && first !== "") {
+        return first;
+    }
+    for (const entry of others) {
+        if (entry !== undefined && entry !== "") {
+            return entry;
+        }
+    }
+    return "";
+}
+exports.coalesce = coalesce;
+/**
+ * coalescelist returns the first non-empty list from the given arguments, or an empty list if
+ * all of the arguments are undefined or empty lists.
+ *
+ * @param first a potentially non-empty array
+ * @param others other potentially non-empty arrays
+ */
+function coalescelist(first, ...others) {
+    if (first !== undefined && first.length !== 0) {
+        return first;
+    }
+    for (const entry of others) {
+        if (entry !== undefined && entry.length !== 0) {
+            return entry;
+        }
+    }
+    return [];
+}
+exports.coalescelist = coalescelist;
+/**
+ * compact removes empty string elements from a list. This can be useful in some cases,
+ * for example when passing joined lists as module variables or when parsing module outputs.
+ *
+ * @param input a string array from which to remove empty values
+ */
+function compact(input) {
+    return input.filter(x => x !== "");
+}
+exports.compact = compact;
+/**
+ * concat combines two or more lists into a single list.
+ *
+ * @param first the first list
+ * @param others other lists
+ */
+function concat(first, ...others) {
+    let result = first;
+    for (const entry of others) {
+        result = result.concat(entry);
+    }
+    return result;
+}
+exports.concat = concat;
+/**
+ * contains returns true if an array contains the given element and returns false otherwise
+ * @param haystack the array in which to search
+ * @param needle the element for which to search
+ */
+function contains(haystack, needle) {
+    return haystack.indexOf(needle) > -1;
+}
+exports.contains = contains;
+function dirname(path) {
+    return Path.win32.dirname(path);
+}
+exports.dirname = dirname;
+function distinct(input) {
+    return input.filter((elem, idx) => input.indexOf(elem) === idx);
+}
+exports.distinct = distinct;
+function element(inputList, elementIndex) {
+    if (inputList.length === 0) {
+        throw new Error("list must not be empty");
+    }
+    if (elementIndex < 0) {
+        throw new Error("elementIndex must be non-negative");
+    }
+    return inputList[elementIndex % inputList.length];
+}
+exports.element = element;
+function file(path) {
+    return fs.readFileSync(path, "utf-8");
+}
+exports.file = file;
+function floor(input) {
+    return Math.floor(input);
+}
+exports.floor = floor;
+/**
+ * format returns a string formatted using the given base string and arguments.
+ *
+ * *NOTE*: This is not a 1-1 map of the Terraform `format` function, since it uses the
+ * node.js `sprintf-js` library instead of the implementation of `fmt.Sprintf` in the Go
+ * standard library. However, it is reasonably close in semantic and will work for a
+ * large number of simple use cases.
+ *
+ * @param formatString a format string
+ * @param args the arguments to be applied to the format string
+ */
+function format(formatString, ...args) {
+    return sprintf_js_1.sprintf(formatString, ...args);
+}
+exports.format = format;
+function formatlist(formatString, ...args) {
+    if (args.length < 1) {
+        throw new Error("At least one list must be passed to formatlist");
+    }
+    const lengths = args.map(x => x.length);
+    if (!lengths.every(x => x === lengths[0])) {
+        throw new Error("All lists passed to formatlist must be the same length");
+    }
+    const result = [];
+    for (let i = 0; i < lengths[0]; i++) {
+        const iterationArgs = args.map(x => x[i]);
+        result.push(sprintf_js_1.sprintf(formatString, ...iterationArgs));
+    }
+    return result;
+}
+exports.formatlist = formatlist;
+function indent(indentSize, stringToIndent) {
+    return stringToIndent.replace(/(\n|\r\n)/mg, le => le + " ".repeat(indentSize));
+}
+exports.indent = indent;
+function index(haystack, needle) {
+    const idx = haystack.indexOf(needle);
+    if (idx > -1) {
+        return idx;
+    }
+    // TODO(jen20): improve the error message to report which needle
+    throw new Error("Could not find needle in haystack");
+}
+exports.index = index;
+function join(separator, ...strings) {
+    const parts = [].concat.apply([], strings);
+    return parts.join(separator);
+}
+exports.join = join;
+function jsonencode(input) {
+    return JSON.stringify(input);
+}
+exports.jsonencode = jsonencode;
+function keys(input) {
+    return Object.keys(input);
+}
+exports.keys = keys;
+function length(input) {
+    if (typeof input === "string") {
+        return input.length;
+    }
+    else if (input instanceof Array) {
+        return input.length;
+    }
+    else {
+        return Object.keys(input).length;
+    }
+}
+exports.length = length;
+function list(...elements) {
+    return elements;
+}
+exports.list = list;
+function log(x, base) {
+    return Math.log(x) / Math.log(base);
+}
+exports.log = log;
+function lookup(inputMap, key, defaultValue) {
+    const val = inputMap[key];
+    if (val === undefined) {
+        if (defaultValue === undefined) {
+            throw new Error("Cannot find key '" + key + "' in map");
+        }
+        else {
+            return defaultValue;
+        }
+    }
+    return val;
+}
+exports.lookup = lookup;
+function lower(input) {
+    return input.toLowerCase();
+}
+exports.lower = lower;
+function map(...keyValuePairs) {
+    if (keyValuePairs.length % 2 !== 0) {
+        throw new Error("Number of parameters to map must be even");
+    }
+    const result = {};
+    for (let i = 0; i < keyValuePairs.length; i += 2) {
+        const key = keyValuePairs[i];
+        result[key] = keyValuePairs[i + 1];
+    }
+    return result;
+}
+exports.map = map;
+function max(...numbers) {
+    return Math.max(...numbers);
+}
+exports.max = max;
+function merge(...maps) {
+    const output = maps[0];
+    for (const x of maps) {
+        for (const y in x) {
+            if (x.hasOwnProperty(y)) {
+                output[y] = x[y];
+            }
+        }
+    }
+    return output;
+}
+exports.merge = merge;
+function min(...numbers) {
+    return Math.min(...numbers);
+}
+exports.min = min;
+function md5(input) {
+    const hash = crypto.createHash("md5");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+exports.md5 = md5;
+function pathexpand(path) {
+    const home = os.homedir();
+    return path.replace(/^~(?=$|\/|\\)/, home);
+}
+exports.pathexpand = pathexpand;
+function pow(base, exponent) {
+    return Math.pow(base, exponent);
+}
+exports.pow = pow;
+function replace(input, toMatch, replacement) {
+    return input.replace(toMatch, replacement);
+}
+exports.replace = replace;
+function sha1(input) {
+    const hash = crypto.createHash("sha1");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+exports.sha1 = sha1;
+function sha256(input) {
+    const hash = crypto.createHash("sha256");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+exports.sha256 = sha256;
+function sha512(input) {
+    const hash = crypto.createHash("sha512");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+exports.sha512 = sha512;
+function signum(input) {
+    if (input === 0) {
+        return 0;
+    }
+    if (input < 0) {
+        return -1;
+    }
+    else {
+        return 1;
+    }
+}
+exports.signum = signum;
+function slice(input, start, end) {
+    if (start < 0) {
+        throw new Error("start must be greater than or equal to 0");
+    }
+    if (end > input.length) {
+        throw new Error("end must be less than or equal to the length of input");
+    }
+    if (start > end) {
+        throw new Error("start must be less than or equal to end");
+    }
+    return input.slice(start, end);
+}
+exports.slice = slice;
+function sort(input) {
+    return input.sort();
+}
+exports.sort = sort;
+function split(separator, input) {
+    return input.split(separator).filter(x => x !== "");
+}
+exports.split = split;
+function substr(input, offset, len) {
+    if (offset < 0) {
+        offset += input.length;
+    }
+    if (len === -1) {
+        len = input.length;
+    }
+    else if (len >= 0) {
+        len += offset;
+    }
+    else {
+        throw new Error("len should be -1, 0 or positive");
+    }
+    if (offset > input.length || offset < 0) {
+        throw new Error("offset may not be larger than the length of input");
+    }
+    if (len > input.length) {
+        throw new Error("offset+length may noe be larger than the length of input");
+    }
+    return input.substr(offset, len);
+}
+exports.substr = substr;
+function transpose(inputMap) {
+    const tempMap = {};
+    for (const entry of Object.keys(inputMap)) {
+        for (const key of inputMap[entry]) {
+            if (tempMap[key] === undefined) {
+                tempMap[key] = new Set();
+            }
+            tempMap[key].add(entry);
+        }
+    }
+    const result = {};
+    for (const entry of Object.keys(tempMap)) {
+        result[entry] = Array.from(tempMap[entry]);
+    }
+    return result;
+}
+exports.transpose = transpose;
+function timestamp() {
+    return (new Date()).toISOString();
+}
+exports.timestamp = timestamp;
+function title(input) {
+    return titleCase(input);
+}
+exports.title = title;
+function trimspace(input) {
+    return input.trim();
+}
+exports.trimspace = trimspace;
+function upper(input) {
+    return input.toUpperCase();
+}
+exports.upper = upper;
+function uuid() {
+    return uuid_1.v4().toString();
+}
+exports.uuid = uuid;
+function urlencode(input) {
+    return encodeURIComponent(input);
+}
+exports.urlencode = urlencode;
+function values(inputMap) {
+    const keyList = keys(inputMap);
+    const result = [];
+    for (const key of keyList) {
+        result.push(inputMap[key]);
+    }
+    return result;
+}
+exports.values = values;
+function zipmap(keyList, valueList) {
+    if (keyList.length !== valueList.length) {
+        throw new Error("key and value lists must be the same length");
+    }
+    const result = {};
+    for (let i = 0; i < keyList.length; i++) {
+        result[keyList[i]] = valueList[i];
+    }
+    return result;
+}
+exports.zipmap = zipmap;

--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,0 +1,608 @@
+{
+  "name": "@pulumi/terraform",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
+      "dev": true
+    },
+    "@types/chai": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
+      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
+      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
+      "dev": true
+    },
+    "@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/validator": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-9.4.4.tgz",
+      "integrity": "sha512-7bWNKQ3lDMhRS2lxe1aHGTBijZ/a6wQfZmCtKJDefpb81sYd+FrfNqj6Gda1Tcw8bYK0gG1CVuNLWV2JS7K8Dw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
+    "ts-node": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
+      "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
+      "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q==",
+      "dev": true
+    }
+  }
+}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pulumi/terraform",
+  "version": "0.1.0",
+  "description": "Helpers for migrating Terraform code to Pulumi",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/pulumi/pulumi-terraform/sdk/nodejs",
+  "files": [
+    "lib/**/*"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^10.14.1",
+    "@types/sprintf-js": "^1.1.2",
+    "@types/uuid": "^3.4.4",
+    "@types/validator": "^9.4.4",
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "tslint": "^5.14.0",
+    "typescript": "^3.3.3333",
+    "validator": "^10.11.0"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "sprintf-js": "^1.1.2",
+    "title-case": "^2.1.1",
+    "uuid": "^3.3.2"
+  },
+  "scripts": {
+    "lint": "tslint -p tsconfig.json",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test && npm run lint",
+    "build": "tsc",
+    "test": "mocha --require ts-node/register test/*.ts"
+  }
+}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -19,6 +19,7 @@
     "@types/validator": "^9.4.4",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
+    "ts-node": "^8.0.3",
     "tslint": "^5.14.0",
     "typescript": "^3.3.3333",
     "validator": "^10.11.0"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulumi/terraform",
-  "version": "0.1.0",
+  "version": "${VERSION}",
   "description": "Helpers for migrating Terraform code to Pulumi",
   "license": "Apache-2.0",
   "repository": "https://github.com/pulumi/pulumi-terraform/sdk/nodejs",

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,0 +1,538 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as bcryptjs from "bcryptjs";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as Path from "path";
+import { sprintf } from "sprintf-js";
+import { v4 } from "uuid";
+import { gzipSync } from "zlib";
+import * as zlib from "zlib";
+
+const titleCase = require("title-case");
+
+/**
+ * abs returns the absolute value of a given number. See also the signum function.
+ *
+ * Examples:
+ *     - `abs(1)` returns `1`
+ *     - `abs(-1)` returns `1`
+ *     - `abs(-3.14)` returns `3.14`
+ *
+ * @param input number for which to return the absolute value
+ */
+export function abs(input: number): number {
+    return Math.abs(input);
+}
+
+/**
+ * basename returns the last element of a path.
+ *
+ * @param path the full path
+ */
+export function basename(path: string): string {
+    return Path.win32.basename(path);
+}
+
+/**
+ * base64decode decodes base64-encoded data and returns the utf-8-encoded string. An
+ * error is thrown if the argument is not valid base64 data.
+ *
+ * @param encoded valid base64-encoded string
+ */
+export function base64decode(encoded: string): string {
+    const decoded = Buffer.from(encoded, "base64").toString("utf-8");
+    if (decoded.length !== ((encoded.length / 4) * 3)) {
+        throw new Error("failed to decode base64 data");
+    }
+
+    return decoded;
+}
+
+/**
+ * base64encode returns a base64-encoded version of the given string.
+ *
+ * @param unencoded the string to encode
+ */
+export function base64encode(unencoded: string): string {
+    return Buffer.from(unencoded).toString("base64");
+}
+
+/**
+ * base64gzip compresses the given string with gzip and then returns the resulting data as
+ * a base64-encoded string.
+ *
+ * @param unencoded the string to compress and encode
+ */
+export function base64gzip(unencoded: string): string {
+    const compressed = gzipSync(unencoded, {
+        level: zlib.constants.Z_DEFAULT_COMPRESSION,
+    });
+    return compressed.toString("base64");
+}
+
+export function base64sha256(input: string): string {
+    const hash = crypto.createHash("sha256");
+    hash.update(input);
+    return hash.digest().toString("base64");
+}
+
+export function base64sha512(input: string): string {
+    const hash = crypto.createHash("sha512");
+    hash.update(input);
+    return hash.digest().toString("base64");
+}
+
+/**
+ * bcrypt returns the Blowfish encrypted hash of the string at the given cost. A default
+ * cost of 10 will be used if not provided.
+ *
+ * @param password password to encrypt
+ * @param cost defaults to 10 if unset
+ */
+export function bcrypt(password: string, cost?: number): string {
+    return bcryptjs.hashSync(password, cost || 10);
+}
+
+/**
+ * ceil returns the smallest integer value greater than or equal to the argument.
+ *
+ * @param input number of which to find the ceiling
+ */
+export function ceil(input: number): number {
+    return Math.ceil(input);
+}
+
+export function chomp(input: string): string {
+    return input.replace(/[\r\n]+$/, "");
+}
+
+/**
+ * chunklist returns a list items chunked by size. For example:
+ *
+ * - chunklist(["id1", "id2", "id3"], 1) returns [["id1"], ["id2"], ["id3"]]
+ * - chunklist(["id1", "id2", "id3"], 2) returns [["id1", "id2"], ["id3"]]
+ *
+ * @param input the list to chunk
+ * @param size the size of each chunk
+ */
+export function chunklist<T>(input: T[], size: number): T[][] {
+    const temp = input.slice(0);
+    const results = [];
+
+    while (temp.length) {
+        results.push(temp.splice(0, size));
+    }
+    return results;
+}
+
+/**
+ * coalesce returns the first non-empty string from the given arguments, or an empty string if all
+ * of the arguments are undefined.
+ *
+ * @param first a potentially non-empty stringj
+ * @param others other potentially non-empty values
+ */
+export function coalesce(first: string | undefined, ...others: (string | undefined)[]): string {
+    if (first !== undefined && first !== "") {
+        return first;
+    }
+
+    for (const entry of others) {
+        if (entry !== undefined && entry !== "") {
+            return entry;
+        }
+    }
+
+    return "";
+}
+
+/**
+ * coalescelist returns the first non-empty list from the given arguments, or an empty list if
+ * all of the arguments are undefined or empty lists.
+ *
+ * @param first a potentially non-empty array
+ * @param others other potentially non-empty arrays
+ */
+export function coalescelist<T>(first: T[] | undefined, ...others: (T[] | undefined)[]): T[] {
+    if (first !== undefined && first.length !== 0) {
+        return first;
+    }
+
+    for (const entry of others) {
+        if (entry !== undefined && entry.length !== 0) {
+            return entry;
+        }
+    }
+
+    return [];
+}
+
+/**
+ * compact removes empty string elements from a list. This can be useful in some cases,
+ * for example when passing joined lists as module variables or when parsing module outputs.
+ *
+ * @param input a string array from which to remove empty values
+ */
+export function compact(input: string[]): string[] {
+    return input.filter(x => x !== "");
+}
+
+/**
+ * concat combines two or more lists into a single list.
+ *
+ * @param first the first list
+ * @param others other lists
+ */
+export function concat<T>(first: T[], ...others: T[][]): T[] {
+    let result = first;
+    for (const entry of others) {
+        result = result.concat(entry);
+    }
+    return result;
+}
+
+/**
+ * contains returns true if an array contains the given element and returns false otherwise
+ * @param haystack the array in which to search
+ * @param needle the element for which to search
+ */
+export function contains<T>(haystack: T[], needle: T): boolean {
+    return haystack.indexOf(needle) > -1;
+}
+
+export function dirname(path: string): string {
+    return Path.win32.dirname(path);
+}
+
+export function distinct(input: string[]): string[] {
+    return input.filter((elem, idx) => input.indexOf(elem) === idx);
+}
+
+export function element(inputList: string[], elementIndex: number) {
+    if (inputList.length === 0) {
+        throw new Error("list must not be empty");
+    }
+    if (elementIndex < 0) {
+        throw new Error("elementIndex must be non-negative");
+    }
+
+    return inputList[elementIndex % inputList.length];
+}
+
+export function file(path: string): string {
+    return fs.readFileSync(path, "utf-8");
+}
+
+export function floor(input: number): number {
+    return Math.floor(input);
+}
+
+/**
+ * format returns a string formatted using the given base string and arguments.
+ *
+ * *NOTE*: This is not a 1-1 map of the Terraform `format` function, since it uses the
+ * node.js `sprintf-js` library instead of the implementation of `fmt.Sprintf` in the Go
+ * standard library. However, it is reasonably close in semantic and will work for a
+ * large number of simple use cases.
+ *
+ * @param formatString a format string
+ * @param args the arguments to be applied to the format string
+ */
+export function format(formatString: string, ...args: any[]): string {
+    return sprintf(formatString, ...args);
+}
+
+export function formatlist(formatString: string, ...args: any[][]): string[] {
+    if (args.length < 1) {
+        throw new Error("At least one list must be passed to formatlist");
+    }
+
+    const lengths = args.map(x => x.length);
+    if (!lengths.every(x => x === lengths[0])) {
+        throw new Error("All lists passed to formatlist must be the same length");
+    }
+
+    const result: string[] = [];
+
+    for (let i = 0; i < lengths[0]; i++) {
+        const iterationArgs = args.map(x => x[i]);
+        result.push(sprintf(formatString, ...iterationArgs));
+    }
+
+    return result;
+}
+
+export function indent(indentSize: number, stringToIndent: string) {
+    return stringToIndent.replace(/(\n|\r\n)/mg, le => le + " ".repeat(indentSize));
+}
+
+export function index<T>(haystack: T[], needle: T): number {
+    const idx = haystack.indexOf(needle);
+    if (idx > -1) {
+        return idx;
+    }
+
+    // TODO(jen20): improve the error message to report which needle
+    throw new Error("Could not find needle in haystack");
+}
+
+export function join(separator: string, ...strings: string[][]) {
+    const parts: string[] = [].concat.apply([], strings);
+
+    return parts.join(separator);
+}
+
+export function jsonencode(input: any): string {
+    return JSON.stringify(input);
+}
+
+export function keys(input: { [k: string]: any }): string[] {
+    return Object.keys(input);
+}
+
+export function length(input: string | any[] | { [k: string]: any }): number {
+    if (typeof input === "string") {
+        return input.length;
+    } else if (input instanceof Array) {
+        return input.length;
+    } else {
+        return Object.keys(input).length;
+    }
+}
+
+export function list<T>(...elements: T[]): T[] {
+    return elements;
+}
+
+export function log(x: number, base: number): number {
+    return Math.log(x) / Math.log(base);
+}
+
+export function lookup<T>(inputMap: { [k: string]: T }, key: string, defaultValue?: T): T {
+    const val = inputMap[key];
+    if (val === undefined) {
+        if (defaultValue === undefined) {
+            throw new Error("Cannot find key '" + key + "' in map");
+        } else {
+            return defaultValue;
+        }
+    }
+
+    return val;
+}
+
+export function lower(input: string): string {
+    return input.toLowerCase();
+}
+
+export function map(...keyValuePairs: any[]): { [k: string]: any } {
+    if (keyValuePairs.length % 2 !== 0) {
+        throw new Error("Number of parameters to map must be even");
+    }
+
+    const result: { [k: string]: any } = {};
+
+    for (let i = 0; i < keyValuePairs.length; i += 2) {
+        const key = keyValuePairs[i];
+        result[key] = keyValuePairs[i + 1];
+    }
+
+    return result;
+}
+
+export function max(...numbers: number[]): number {
+    return Math.max(...numbers);
+}
+
+export function merge(...maps: { [k: string]: any }[]): { [k: string]: any } {
+    const output = maps[0];
+    for (const x of maps) {
+        for (const y in x) {
+            if (x.hasOwnProperty(y)) {
+                output[y] = x[y];
+            }
+        }
+    }
+
+    return output;
+}
+
+export function min(...numbers: number[]): number {
+    return Math.min(...numbers);
+}
+
+export function md5(input: string): string {
+    const hash = crypto.createHash("md5");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+
+export function pathexpand(path: string): string {
+    const home = os.homedir();
+    return path.replace(/^~(?=$|\/|\\)/, home);
+}
+
+export function pow(base: number, exponent: number): number {
+    return Math.pow(base, exponent);
+}
+
+export function replace(input: string, toMatch: string | RegExp, replacement: string): string {
+    return input.replace(toMatch, replacement);
+}
+
+export function sha1(input: string): string {
+    const hash = crypto.createHash("sha1");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+
+export function sha256(input: string): string {
+    const hash = crypto.createHash("sha256");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+
+export function sha512(input: string): string {
+    const hash = crypto.createHash("sha512");
+    hash.update(input);
+    return hash.digest().toString("hex");
+}
+
+export function signum(input: number): number {
+    if (input === 0) {
+        return 0;
+    }
+    if (input < 0) {
+        return -1;
+    } else {
+        return 1;
+    }
+}
+
+export function slice(input: string[], start: number, end: number): string[] {
+    if (start < 0) {
+        throw new Error("start must be greater than or equal to 0");
+    }
+    if (end > input.length) {
+        throw new Error("end must be less than or equal to the length of input");
+    }
+    if (start > end) {
+        throw new Error("start must be less than or equal to end");
+    }
+
+    return input.slice(start, end);
+}
+
+export function sort(input: string[]): string[] {
+    return input.sort();
+}
+
+export function split(separator: string, input: string): string[] {
+    return input.split(separator).filter(x => x !== "");
+}
+
+export function substr(input: string, offset: number, len: number): string {
+    if (offset < 0) {
+        offset += input.length;
+    }
+
+    if (len === -1) {
+        len = input.length;
+    } else if (len >= 0) {
+        len += offset;
+    } else {
+        throw new Error("len should be -1, 0 or positive");
+    }
+
+    if (offset > input.length || offset < 0) {
+        throw new Error("offset may not be larger than the length of input");
+    }
+
+    if (len > input.length) {
+        throw new Error("offset+length may noe be larger than the length of input");
+    }
+
+    return input.substr(offset, len);
+}
+
+export function transpose(inputMap: { [k: string]: string[] }): { [k: string]: string[] } {
+    const tempMap: { [k: string]: Set<string> } = {};
+
+    for (const entry of Object.keys(inputMap)) {
+        for (const key of inputMap[entry]) {
+            if (tempMap[key] === undefined) {
+                tempMap[key] = new Set<string>();
+            }
+
+            tempMap[key].add(entry);
+        }
+    }
+
+    const result: { [k: string]: string[] } = {};
+    for (const entry of Object.keys(tempMap)) {
+        result[entry] = Array.from(tempMap[entry]);
+    }
+    return result;
+}
+
+export function timestamp(): string {
+    return (new Date()).toISOString();
+}
+
+export function title(input: string): string {
+    return titleCase(input);
+}
+
+export function trimspace(input: string): string {
+    return input.trim();
+}
+
+export function upper(input: string): string {
+    return input.toUpperCase();
+}
+
+export function uuid(): string {
+    return v4().toString();
+}
+
+export function urlencode(input: string): string {
+    return encodeURIComponent(input);
+}
+
+export function values<T>(inputMap: { [k: string]: T }): T[] {
+    const keyList = keys(inputMap);
+
+    const result: T[] = [];
+    for (const key of keyList) {
+        result.push(inputMap[key]);
+    }
+
+    return result;
+}
+
+export function zipmap<T>(keyList: string[], valueList: T[]): { [k: string]: T } {
+    if (keyList.length !== valueList.length) {
+        throw new Error("key and value lists must be the same length");
+    }
+
+    const result: { [k: string]: T } = {};
+    for (let i = 0; i < keyList.length; i++) {
+        result[keyList[i]] = valueList[i];
+    }
+
+    return result;
+}

--- a/sdk/nodejs/test/testdata/test-file.txt
+++ b/sdk/nodejs/test/testdata/test-file.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/sdk/nodejs/test/tests.ts
+++ b/sdk/nodejs/test/tests.ts
@@ -1,0 +1,597 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as bcryptjs from "bcryptjs";
+import { assert } from "chai";
+import * as os from "os";
+import * as path from "path";
+import { gunzipSync } from "zlib";
+import * as sut from "../src/index";
+
+const validator = require("validator");
+
+describe("abs", () => {
+    it("works", () => {
+        assert.equal(sut.abs(1), 1);
+        assert.equal(sut.abs(-1), 1);
+        assert.equal(sut.abs(-3.14), 3.14);
+        assert.equal(sut.abs(42.001), 42.001);
+    });
+});
+
+describe("basename", () => {
+    it("works for unix paths", () => {
+        assert.equal(sut.basename("/foo/bar/baz"), "baz");
+    });
+
+    it("works for Windows paths", () => {
+        assert.equal(sut.basename("C:\\Windows\\system32\\kernel32.dll"), "kernel32.dll");
+    });
+});
+
+describe("base64decode", () => {
+    it("works with valid base64-encoded input", () => {
+        assert.equal(sut.base64decode("YWJjMTIzIT8kKiYoKSctPUB+"), "abc123!?$*&()'-=@~");
+    });
+
+    it("throws with invalid base64-encoded input", () => {
+        assert.throws(() => sut.base64decode("this-is-an-invalid-base64-data"));
+    });
+});
+
+describe("base64encode", () => {
+    it("works", () => {
+        assert.equal(sut.base64encode("abc123!?$*&()'-=@~"), "YWJjMTIzIT8kKiYoKSctPUB+");
+    });
+});
+
+describe("base64gzip", () => {
+    it("works", () => {
+        const zipped = sut.base64gzip("test");
+
+        assert.equal(gunzipSync(Buffer.from(zipped, "base64")).toString("utf-8"), "test");
+    });
+});
+
+describe("base64sha256", () => {
+    it("works", () => {
+        assert.equal(sut.base64sha256("test"), "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=");
+    });
+
+    it("is different to base64encode(sha256(input))", () => {
+        assert.equal(sut.base64encode(sut.sha256("test")),
+            "OWY4NmQwODE4ODRjN2Q2NTlhMmZlYWEwYzU1YWQwMTVhM2JmNGYxYjJiMGI4MjJjZDE1ZDZjMTViMGYwMGEwOA==");
+    });
+});
+
+describe("base64sha512", () => {
+    it("works", () => {
+        assert.equal(sut.base64sha512("test"),
+            "7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==");
+    });
+
+    it("is different to base64encode(sha512(input))", () => {
+        assert.equal(sut.base64encode(sut.sha512("test")),
+            "ZWUyNmIwZGQ0YWY3ZTc0OWFhMWE4ZWUzYzEwYWU5OTIzZjYxODk4MDc3MmU0NzNmODgxOWE1ZDQ5NDBlMGRiMjdhYzE4NWY4YTBlM" +
+            "WQ1Zjg0Zjg4YmM4ODdmZDY3YjE0MzczMmMzMDRjYzVmYTlhZDhlNmY1N2Y1MDAyOGE4ZmY=");
+    });
+});
+
+describe("bcrypt", () => {
+    it("works with default cost", () => {
+        const hash = sut.bcrypt("test");
+        assert.isTrue(bcryptjs.compareSync("test", hash));
+    }).timeout(8000);
+
+    it("works with overridden cost", () => {
+        const hash = sut.bcrypt("test", 5);
+        assert.isTrue(bcryptjs.compareSync("test", hash));
+    }).timeout(5000);
+});
+
+describe("ceil", () => {
+    it("works for positive numbers", () => {
+        assert.equal(sut.ceil(1.2), 2);
+    });
+
+    it("works for negative numbers", () => {
+        assert.equal(sut.ceil(-1.2), -1);
+    });
+});
+
+describe("chomp", () => {
+    it("does not affect strings with no trailing newlines", () => {
+        assert.equal(sut.chomp("hello\ncruel\nworld"), "hello\ncruel\nworld");
+    });
+
+    it("does not affect leading newlines", () => {
+        assert.equal(sut.chomp("\n\nhello\ncruel\nworld"), "\n\nhello\ncruel\nworld");
+    });
+
+    it("works for strings with one UNIX trailing newline", () => {
+        assert.equal(sut.chomp("hello\ncruel\nworld\n"), "hello\ncruel\nworld");
+    });
+
+    it("works for strings with multiple UNIX trailing newlines", () => {
+        assert.equal(sut.chomp("hello\ncruel\nworld\n\n\n"), "hello\ncruel\nworld");
+    });
+
+    it("works for strings with one Windows trailing newline", () => {
+        assert.equal(sut.chomp("hello\r\ncruel\r\nworld\r\n"), "hello\r\ncruel\r\nworld");
+    });
+
+    it("works for strings with multiple Windows trailing newline", () => {
+        assert.equal(sut.chomp("hello\r\ncruel\r\nworld\r\n\r\n"), "hello\r\ncruel\r\nworld");
+    });
+});
+
+describe("chunklist", () => {
+    it("chunks single items", () => {
+        assert.deepEqual(sut.chunklist(["id1", "id2", "id3"], 1), [["id1"], ["id2"], ["id3"]]);
+    });
+
+    it("gives chunks of equal size with remainder in last chunk", () => {
+        assert.deepEqual(sut.chunklist(["id1", "id2", "id3", "id4", "id5"], 2),
+            [["id1", "id2"], ["id3", "id4"], ["id5"]]);
+    });
+
+    it("works for other types", () => {
+        assert.deepEqual(sut.chunklist([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+    });
+});
+
+describe("coalesce", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.coalesce("first", "second", "third"), "first");
+        assert.equal(sut.coalesce("", "second", "third"), "second");
+        assert.equal(sut.coalesce("", "", ""), "");
+    });
+});
+
+describe("coalescelist", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.coalescelist(["first"], ["second"], ["third"]), ["first"]);
+        assert.deepEqual(sut.coalescelist([], ["second"], ["third"]), ["second"]);
+        assert.deepEqual(sut.coalescelist([], [], []), []);
+    });
+});
+
+describe("compact", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.compact(["", "", "first", "second"]), ["first", "second"]);
+        assert.deepEqual(sut.compact(["", "", "first", "second", ""]), ["first", "second"]);
+        assert.deepEqual(sut.compact([""]), []);
+    });
+});
+
+describe("concat", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.concat(["", "first", ""]),
+            ["", "first", ""]);
+        assert.deepEqual(sut.concat(["", "first", ""], ["second", "third"]),
+            ["", "first", "", "second", "third"]);
+        assert.deepEqual(sut.concat(["first"], ["second"], ["third"]),
+            ["first", "second", "third"]);
+        assert.deepEqual(sut.concat([{key: "value"}], [{key2: "value2"}]),
+            [{key: "value"}, {key2: "value2"}]);
+    });
+});
+
+describe("contains", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.contains([1, 2, 3, 4, 5], 6), false);
+        assert.equal(sut.contains([1, 2, 3, 4, 5], 1), true);
+        assert.equal(sut.contains(["first", "", "second", "third"], ""), true);
+        assert.equal(sut.contains(["first", "", "second", "third"], "second"), true);
+        assert.equal(sut.contains(["first", "", "second", "third"], "fourth"), false);
+    });
+});
+
+describe("dirname", () => {
+    it("works for unix paths", () => {
+        assert.equal(sut.dirname("/foo/bar/baz"), "/foo/bar");
+    });
+
+    it("works for Windows paths", () => {
+        assert.equal(sut.dirname("C:\\Windows\\system32\\kernel32.dll"), "C:\\Windows\\system32");
+    });
+});
+
+describe("distinct", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.distinct(["a", "a", "b"]), ["a", "b"]);
+        assert.deepEqual(sut.distinct(["a", "b", "c"]), ["a", "b", "c"]);
+    });
+});
+
+describe("element", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.element(["a", "b"], 0), "a");
+        assert.equal(sut.element(["a", "b"], 1), "b");
+        assert.equal(sut.element(["a", "b"], 2), "a");
+
+        assert.throws(() => sut.element([], 1));
+        assert.throws(() => sut.element(["a", "b"], -1));
+    });
+});
+
+describe("file", () => {
+    it("reads a file", () => {
+        const testFilePath = path.join(__dirname, "testdata", "test-file.txt");
+        assert.equal(sut.file(testFilePath), "Hello World\n");
+    });
+});
+
+describe("floor", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.floor(-1.3), -2);
+        assert.equal(sut.floor(1.7), 1);
+    });
+});
+
+describe("format", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.format("hello"), "hello");
+        assert.equal(sut.format("hello %s", "world"), "hello world");
+        assert.equal(sut.format("hello %d", 42), "hello 42");
+        assert.equal(sut.format("hello %05d", 42), "hello 00042");
+        assert.equal(sut.format("hello %05d", 12345), "hello 12345");
+    });
+});
+
+describe("formatlist", () => {
+    it("passes Terraform tests", () => {
+        assert.throws(() => sut.formatlist("hello"));
+        assert.throws(() => sut.formatlist("hello %s", ["world"], ["world2", "world3"]));
+
+        assert.deepEqual(sut.formatlist("<%s>", ["A", "B"]), ["<A>", "<B>"]);
+        assert.deepEqual(sut.formatlist("%s=%d", ["A", "B", "C"], [1, 2, 3]), ["A=1", "B=2", "C=3"]);
+
+        assert.deepEqual(sut.formatlist("%s", [], []), []);
+    });
+});
+
+describe("indent", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.indent(4, "Fleas:\nAdam\nHad'em\n\nE.E. Cummings"),
+            "Fleas:\n    Adam\n    Had'em\n    \n    E.E. Cummings");
+        assert.equal(sut.indent(4, "oneliner"), "oneliner");
+        assert.equal(sut.indent(8, "#!/usr/bin/env bash\ndate\npwd\n"),
+            "#!/usr/bin/env bash\n        date\n        pwd\n        ");
+    });
+
+    it("works with Windows strings", () => {
+        assert.equal(sut.indent(8, "#!/usr/bin/env bash\r\ndate\r\npwd\r\n"),
+            "#!/usr/bin/env bash\r\n        date\r\n        pwd\r\n        ");
+    });
+});
+
+describe("index", () => {
+    it("passes Terraform tests", () => {
+        assert.throws(() => sut.index(["notfoo", "stillnotfoo", "bar"], "foo"));
+        assert.equal(sut.index(["foo"], "foo"), 0);
+        assert.equal(sut.index(["foo", "spam", "bar", "eggs"], "bar"), 2);
+    });
+});
+
+describe("join", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.join(", ", ["hello", "world"]), "hello, world");
+        assert.equal(sut.join(".", ["10", "11", "12", "13"]), "10.11.12.13");
+    });
+
+    it("works with multiple lists", () => {
+        assert.equal(sut.join(", ", ["hello", "world"], ["goodbye", "world"]),
+            "hello, world, goodbye, world");
+    });
+});
+
+describe("jsonencode", () => {
+    it("works for a string", () => {
+        assert.equal(sut.jsonencode("test"), "\"test\"");
+    });
+
+    it("works for an array", () => {
+        assert.equal(sut.jsonencode(["hello", "world"]), "[\"hello\",\"world\"]");
+    });
+
+    it("works with objects", () => {
+        assert.equal(sut.jsonencode({key: "value", key2: ["array1", "array2"]}),
+            "{\"key\":\"value\",\"key2\":[\"array1\",\"array2\"]}");
+    });
+});
+
+describe("keys", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.keys({bar: "baz", qux: "quack"}), ["bar", "qux"]);
+    });
+});
+
+describe("length", () => {
+    it("returns number of characters in a string", () => {
+        assert.equal(sut.length("hello"), 5);
+    });
+    it("returns the number of elements in an array", () => {
+        assert.equal(sut.length(["a", "b", "c"]), 3);
+    });
+    it("returns the number of keys in an object", () => {
+        assert.equal(sut.length({foo: "bar", baz: "qux"}), 2);
+    });
+});
+
+describe("list", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.list(), []);
+        assert.deepEqual(sut.list("hello"), ["hello"]);
+        assert.deepEqual(sut.list("hello", ...["hello", "world"]), ["hello", "hello", "world"]);
+        assert.deepEqual(sut.list({key: "value1"}, {key: "value2"}), [{key: "value1"}, {key: "value2"}]);
+    });
+});
+
+describe("log", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.log(1, 10), 0);
+        assert.equal(sut.log(10, 10), 1);
+        assert.equal(sut.log(0, 10), -Infinity);
+        assert.equal(sut.log(10, 0), 0);
+    });
+});
+
+describe("lookup", () => {
+    it("passes Terraform tests", () => {
+        const exampleMap = {
+            bar: "baz",
+        };
+
+        assert.equal(sut.lookup(exampleMap, "bar"), "baz");
+        assert.throws(() => sut.lookup(exampleMap, "baz"));
+        assert.equal(sut.lookup(exampleMap, "baz", "foo"), "foo");
+    });
+});
+
+describe("lower", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.lower("HELLO"), "hello");
+        assert.equal(sut.lower("hello"), "hello");
+        assert.equal(sut.lower(""), "");
+    });
+});
+
+describe("map", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.map("key1", "value1", "key2", "value2"), {key1: "value1", key2: "value2"});
+        assert.deepEqual(sut.map("key1", 1, "key2", 2), {key1: 1, key2: 2});
+    });
+});
+
+describe("max", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.max(-1, 0, 1), 1);
+        assert.equal(sut.max(-1, -2), -1);
+        assert.equal(sut.max(-1, -2, 42), 42);
+    });
+});
+
+describe("merge", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.merge({a: "b"}, {c: "d"}), {a: "b", c: "d"});
+        assert.deepEqual(sut.merge({a: "b"}, {a: "d"}), {a: "d"});
+        assert.deepEqual(sut.merge({a: 1}, {a: "hello"}), {a: "hello"});
+    });
+});
+
+describe("min", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.min(-1, 0, 1), -1);
+        assert.equal(sut.min(-1, -2), -2);
+        assert.equal(sut.min(-1, -2, 42), -2);
+    });
+});
+
+describe("md5", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.md5("tada"), "ce47d07243bb6eaf5e1322c81baf9bbf");
+        assert.equal(sut.md5(" tada "), "aadf191a583e53062de2d02c008141c4");
+        assert.equal(sut.md5(""), "d41d8cd98f00b204e9800998ecf8427e");
+    });
+});
+
+describe("pathexpand", () => {
+    it("passes Terraform tests", () => {
+        const homedir = os.homedir();
+
+        assert.equal(sut.pathexpand("~/hello.txt"), `${homedir}/hello.txt`);
+        assert.equal(sut.pathexpand("~/a/test/file"), `${homedir}/a/test/file`);
+        assert.equal(sut.pathexpand("/a/test/file"), `/a/test/file`);
+        assert.equal(sut.pathexpand("/"), `/`);
+    });
+});
+
+describe("pow", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.pow(3, 2), 9);
+        assert.equal(sut.pow(4, 0), 1);
+    });
+});
+
+describe("replace", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.replace("hello", "hel", "bel"), "bello");
+        assert.equal(sut.replace("hello", "nope", "bel"), "hello");
+        assert.equal(sut.replace("hello", /l/g, "L"), "heLLo");
+        assert.equal(sut.replace("hello", /(l)/, "$1"), "hello");
+        assert.equal(sut.replace("helo", /(l)/, "$1$1"), "hello");
+    });
+});
+
+describe("sha1", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.sha1("test"), "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+    });
+});
+
+describe("sha256", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.sha256("test"), "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
+    });
+});
+
+describe("sha512", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.sha512("test"),
+            "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b1437" +
+            "32c304cc5fa9ad8e6f57f50028a8ff");
+    });
+});
+
+describe("signum", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.signum(-10), -1);
+        assert.equal(sut.signum(0), 0);
+        assert.equal(sut.signum(10), 1);
+    });
+});
+
+describe("slice", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.slice(["a", "b", "c"], 1, 1), []);
+        assert.deepEqual(sut.slice(["a", "b", "c"], 1, 2), ["b"]);
+        assert.deepEqual(sut.slice(["a", "b", "c"], 0, 2), ["a", "b"]);
+
+        assert.throws(() => sut.slice(["a"], -1, 0));
+        assert.throws(() => sut.slice(["a", "b", "c"], 2, 1));
+        assert.throws(() => sut.slice(["a", "b", "c"], 1, 4));
+    });
+});
+
+describe("sort", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.sort(["c", "a", "b"]), ["a", "b", "c"]);
+    });
+});
+
+describe("split", () => {
+    it("passes Terraform tests", () => {
+        assert.deepEqual(sut.split(",", "a,,b"), ["a", "b"]);
+        assert.deepEqual(sut.split(",", "a,b,"), ["a", "b"]);
+        assert.deepEqual(sut.split(",", ""), []);
+    });
+});
+
+describe("substr", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.substr("foobar", 0, 0), "");
+        assert.equal(sut.substr("foobar", 0, -1), "foobar");
+        assert.equal(sut.substr("foobar", 0, 3), "foo");
+        assert.equal(sut.substr("foobar", 3, 3), "bar");
+        assert.equal(sut.substr("foobar", -3, 3), "bar");
+        assert.equal(sut.substr("", 0, 0), "");
+        assert.throws(() => sut.substr("foo", -4, -1));
+        assert.throws(() => sut.substr("", 1, 0));
+        assert.throws(() => sut.substr("", 0, 1));
+        assert.throws(() => sut.substr("", 0, -2));
+    });
+});
+
+describe("timestamp", () => {
+    it("passes Terraform tests", () => {
+        assert.isTrue(validator.isRFC3339(sut.timestamp()));
+    });
+});
+
+describe("title", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.title(""), "");
+        assert.equal(sut.title("hello"), "Hello");
+        assert.equal(sut.title("hello world"), "Hello World");
+    });
+});
+
+describe("transpose", () => {
+    it("passes Terraform tests", () => {
+        const inputMap = {
+            key1: ["a", "b"],
+            key2: ["a", "b", "c"],
+            key3: ["c"],
+            key4: [],
+        };
+        const expectedMap = {
+            "a": ["key1", "key2"],
+            "b": ["key1", "key2"],
+            "c": ["key2", "key3"],
+        };
+
+        assert.deepEqual(sut.transpose(inputMap), expectedMap);
+    });
+});
+
+describe("trimspace", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.trimspace(" test "), "test");
+    });
+});
+
+describe("upper", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.upper("HELLO"), "HELLO");
+        assert.equal(sut.upper("hello"), "HELLO");
+    });
+});
+
+describe("urlencode", () => {
+    it("passes Terraform tests", () => {
+        assert.equal(sut.urlencode("abc123-_"), "abc123-_");
+        assert.equal(sut.urlencode("foo:bar@localhost?foo=bar&bar=baz"),
+            "foo%3Abar%40localhost%3Ffoo%3Dbar%26bar%3Dbaz");
+        assert.equal(sut.urlencode("mailto:email?subject=this+is+my+subject"),
+            "mailto%3Aemail%3Fsubject%3Dthis%2Bis%2Bmy%2Bsubject");
+        assert.equal(sut.urlencode("foo/bar"), "foo%2Fbar");
+    });
+});
+
+describe("uuid", () => {
+    it("passes Terraform tests", () => {
+        const validUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+        const generated1 = sut.uuid();
+        const generated2 = sut.uuid();
+
+        assert.match(generated1, validUUID);
+        assert.match(generated2, validUUID);
+        assert.notEqual(generated1, generated2);
+    });
+});
+
+describe("values", () => {
+    it("passes Terraform tests", () => {
+        const map = {
+            key: "value",
+            key2: "value2",
+            key3: "value3",
+        };
+
+        assert.deepEqual(sut.values(map), ["value", "value2", "value3"]);
+    });
+});
+
+describe("zipmap", () => {
+    it("passes Terraform tests", () => {
+        const keyList = ["Hello", "World"];
+        const valueList = ["foo", "bar"];
+
+        assert.deepEqual(sut.zipmap(keyList, valueList), {"Hello": "foo", "World": "bar"});
+
+        assert.throws(() => sut.zipmap(keyList, ["foo"]));
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "lib",
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "sourceMap": false,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true
+  },
+  "files": [
+    "src/index.ts"
+  ]
+}
+

--- a/sdk/nodejs/tslint.json
+++ b/sdk/nodejs/tslint.json
@@ -1,0 +1,128 @@
+{
+    "rules": {
+        "align": [
+            true,
+            "parameters",
+            "statements"
+        ],
+        "ban": false,
+        "class-name": true,
+        "comment-format": [
+            true,
+            "check-space"
+        ],
+        "curly": true,
+        "eofline": true,
+        "file-header": [
+            true,
+            "Copyright \\d{4}-\\d{4}, Pulumi Corporation."
+        ],
+        "forin": true,
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "interface-name": false,
+        "jsdoc-format": false,
+        "label-position": true,
+        "max-line-length": [
+            true,
+            120
+        ],
+        "member-access": false,
+        "member-ordering": [
+            true,
+            "static-before-instance",
+            "variables-before-functions"
+        ],
+        "no-any": false,
+        "no-arg": true,
+        "no-bitwise": false,
+        "no-conditional-assignment": false,
+        "no-consecutive-blank-lines": false,
+        "no-console": [
+            true,
+            "debug",
+            "info",
+            "time",
+            "timeEnd",
+            "trace"
+        ],
+        "no-construct": true,
+        "no-debugger": true,
+        "no-duplicate-variable": true,
+        "no-empty": true,
+        "no-eval": true,
+        "no-inferrable-types": false,
+        "no-internal-module": true,
+        "no-parameter-properties": false,
+        "no-require-imports": false,
+        "no-shadowed-variable": true,
+        "no-string-literal": false,
+        "no-switch-case-fall-through": true,
+        "no-trailing-whitespace": true,
+        "no-unused-expression": true,
+        "no-use-before-declare": false,
+        "no-var-keyword": true,
+        "no-var-requires": false,
+        "object-literal-sort-keys": false,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-whitespace"
+        ],
+        "ordered-imports": true,
+        "prefer-const": true,
+        "quotemark": [
+            true,
+            "double",
+            "avoid-escape"
+        ],
+        "radix": true,
+        "semicolon": true,
+        "switch-default": true,
+        "trailing-comma": [
+            true,
+            {
+                "multiline": "always",
+                "singleline": "never"
+            }
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef": [
+            false,
+            "call-signature",
+            "parameter",
+            "property-declaration",
+            "variable-declaration",
+            "member-variable-declaration"
+        ],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "variable-name": [
+            true,
+            "check-format",
+            "allow-leading-underscore",
+            "ban-keywords"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-module",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}


### PR DESCRIPTION
This PR is work in progress to fix #267.

The interpolation functions in Terraform are as follows (checked off when part of this PR, or with notes beside them):

- [x] `abs`
- [x] `basename`
- [x] `base64decode`
- [x] `base64encode`
- [ ] `base64gzip` - implemented but `gzip` options appear different so test cases do not pass 1-1
- [x] `base64sha256`
- [x] `base64sha512`
- [x] `bcrypt`
- [x] `ceil`
- [x] `chomp`
- [x] `chunklist`
- [ ] `cidrhost`
- [ ] `cidrnetmask`
- [ ] `cidrsubnet`
- [x] `coalesce`
- [x] `coalescelist`
- [x] `compact`
- [x] `concat`
- [x] `contains`
- [x] `dirname`
- [x] `distinct`
- [x] `element`
- [x] `file`
- [ ] `flatten`
- [x] `floor`
- [x] `format`
- [x] `formatlist`
- [x] `indent`
- [x] `index`
- [x] `join`
- [x] `jsonencode`
- [x] `keys`
- [x] `length`
- [x] `list`
- [x] `log`
- [x] `lower`
- [x] `map`
- [x] `max`
- [ ] `matchkeys`
- [x] `md5`
- [x] `merge`
- [x] `min`
- [x] `pathexpand`
- [x] `pow`
- [x] `uuid`
- [x] `replace`
- [ ] `rsadecrypt`
- [x] `sha1`
- [x] `sha256`
- [x] `sha512`
- [x] `signum`
- [x] `slice`
- [x] `sort`
- [x] `split`
- [x] `substr`
- [x] `timestamp`
- [ ] `timeadd`
- [x] `title`
- [x] `transpose`
- [x] `trimspace`
- [x] `upper`
- [x] `values`
- [x] `urlencode`
- [x] `zipmap`

There is a minimal set of runtime dependencies (and several more development dependencies).

Still do do:

- [ ] Implement remaining functions
- [ ] Ensure appropriate documentation comments are included
- [ ] Ensure the package build is hooked into the build system
- [ ] Ensure all tests pass and are hooked into the build system