### PR TITLE
Look up Pulumi schema by mangled resource name in getInfoFromPulumiName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 /vendor/
-
+/.idea/
+*.iml

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -778,7 +778,7 @@ func getInfoFromPulumiName(key resource.PropertyKey,
 		// Otherwise, transform the Pulumi name to the Terraform name using the standard mangling scheme.
 		name = PulumiToTerraformName(ks, tfs)
 	}
-	return name, tfs[name], ps[ks]
+	return name, tfs[name], ps[name]
 }
 
 // CleanTerraformSchema recursively removes "Removed" properties from a map[string]*schema.Schema.


### PR DESCRIPTION
`getInfoFromPulumiName` is used as part of the schema resolution in the `Check` phase of tfbridge, and the Pulumi Schema is used to determine whether there is a value transformer or not (as of e741081).

The Pulumi schema is returned by indexing into `ps`, a `map[string]*tfbridge.SchemaInfo`. The keys of the map are in the mangled Terraform underscore_separated format, as is verifiable with a debugger, in this case for an `aws.iam.Role` (or `aws_iam_role`) resource:

```
0.031s ps=map[string]*tfbridge.SchemaInfo{
           "name": &tfbridge.SchemaInfo{
               Name:      "name",
               Type:      "",
               AltTypes:  nil,
               Transform: tfbridge.Transformer {...},
               Elem:      (*tfbridge.SchemaInfo)(nil),
               Fields:    {},
               Asset:     (*tfbridge.AssetTranslation)(nil),
               Default:   &tfbridge.DefaultInfo{
                   From:    func(*tfbridge.PulumiResource) (interface {}, error) {...},
                   Value:   nil,
                   EnvVars: nil,
               },
               Stable:      (*bool)(nil),
               MaxItemsOne: (*bool)(nil),
           },
           "assume_role_policy": &tfbridge.SchemaInfo{
               Name:        "",
               Type:        "string",
               AltTypes:    {"aws:iam/documents:PolicyDocument"},
               Transform:   tfbridge.Transformer {...},
               Elem:        (*tfbridge.SchemaInfo)(nil),
               Fields:      {},
               Asset:       (*tfbridge.AssetTranslation)(nil),
               Default:     (*tfbridge.DefaultInfo)(nil),
               Stable:      (*bool)(nil),
               MaxItemsOne: (*bool)(nil),
           },
       }
```

However, the `getInfoFromPulumiName` function indexed into `ps` using a non-mangled name - yielding a Terraform schema but no Pulumi schema, and consequently no transformer - giving the errors seen in pulumi/pulumi-aws#356 where a non-transformed value is passed through erroneously to the Terraform provider.

This commit fixes the lookup to use `name` instead of `ks`, which will respect the `rawName` argument.

It's unclear to me the best way to approach adding some test coverage here, or whether this is indeed the only way to fix this issue (which seems unlikely since this did work at some point, and the code in question has not been modified in some time). That said, this definitely seems more correct, and I have verified it fixes pulumi/pulumi-aws#356 and does not cause any test failures.
