### PR TITLE
Move pulumi/pulumi dep to master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -392,6 +392,7 @@
   version = "v1.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/diag",
@@ -403,6 +404,7 @@
     "pkg/resource/provider",
     "pkg/tokens",
     "pkg/tools",
+    "pkg/util/ciutil",
     "pkg/util/cmdutil",
     "pkg/util/contract",
     "pkg/util/fsutil",
@@ -416,8 +418,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "c7d3cc5731d0ca2b26ad5e18e6a23b43b74b44b7"
-  version = "v0.15.1"
+  revision = "0e868f15fc3aad99ac77eca29f8c0600a27b5ae3"
 
 [[projects]]
   branch = "master"
@@ -696,6 +697,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8fb003c2592d8600f353f25e8816e349cc9dbdd558005ecae2d47d82fe4f600d"
+  inputs-digest = "b29f67b36b2c315bc1b93182380d5c4445ddfbf4940be2b57f1e4d55b0bfc5ec"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/pulumi/pulumi"
-  version = "v0.15.1"
+  branch = "master"
 
 # Redirect all Terraform references to our fork.
 [[override]]


### PR DESCRIPTION
We were previously locked to an older v0.15.1 which prevents pulling recent updates in pulumi/pulumi into TF-based providers.

We will let this float in master so that TF-based providers can use the versions they need.