### PR TITLE
Add ability to skip a Terraform importer

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -45,11 +45,23 @@ type ProviderInfo struct {
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.
 type ResourceInfo struct {
-	Tok                 tokens.Type            // a type token to override the default; "" uses the default.
-	Fields              map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
-	IDFields            []string               // an optional list of ID alias fields.
-	Docs                *DocInfo               // overrides for finding and mapping TF docs.
-	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
+	// a type token to override the default; "" uses the default.
+	Tok tokens.Type
+
+	// a map of custom field names; if a type is missing, uses the default.
+	Fields map[string]*SchemaInfo
+
+	// an optional list of ID alias fields.
+	IDFields []string
+
+	// Overrides for finding and mapping TF docs.
+	Docs *DocInfo
+
+	// If true, Pulumi will delete before creating new replacement resources.
+	DeleteBeforeReplace bool
+
+	// If true, any importer specified in the Terraform schema will not be called during read.
+	SkipTFImporterOnRead bool
 }
 
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -68,6 +68,13 @@ func (res *Resource) collectImporterAttributes(resourceID resource.ID, inputs ma
 		return nil
 	}
 
+	// Even if there is a Terraform importer defined, we may choose to override it because it
+	// doesn't behave in a manner compatible with our Read function.
+	if res.Schema.SkipTFImporterOnRead {
+		glog.V(9).Infof("%s has TF Importer but marked as SkipTFImporterOnRead", res.TFName)
+		return nil
+	}
+
 	glog.V(9).Infof("%s has TF Importer", res.TFName)
 
 	id := resourceID.String()


### PR DESCRIPTION
During the implementation of #275, we made the assumption that it is always safe to run the Terraform importer specified for a resource as part of the read operation. During the rollout of this change to some ofthe more boutique providers (e.g. Random, and some resources in AWS), it was discovered by Matt that this does not hold, and that we introduce read errors because the format expected by the importer is not an ID or something which can be transformed into one.

This commit adds an option to the Pulumi schema for a resource to skip running the Terraform importer defined for that resource type, which should restore the old behaviour, while allowing the majority of resources for which running the importer is OK to retain their newer behaviour.

It may be the case in future that we want the ability to not just skip the Terraform importer but to define our own importer instead - if this is added, it should be considered that skipping the Terraform importer for resources with a Pulumi importer is desired, but this is a good first step.