### PR TITLE
Split documentation H1 at first occurence only

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -201,11 +201,14 @@ func parseTFMarkdown(kind DocKind, markdown string, provider string, rawname str
 				}
 			}
 		case "---":
-			// Extract the description section
-			subparts := strings.Split(section, "\n# ")
+			// Extract the description section. We assume here that the first H1 (line starting with #) is the name
+			// of the resource, because we aren't detecting code fencing. Comments in HCL are prefixed with # (the
+			// same as H1 in Markdown, so we treat further H1's in this section as part of the description. If there
+			// are no matching H1s, we emit a warning for the resource as it is likely a problem with the documentation.
+			subparts := strings.SplitN(section, "\n# ", 2)
 			if len(subparts) != 2 {
 				cmdutil.Diag().Warningf(
-					diag.Message("", "Expected only a single H1 in markdown for resource %v"), rawname)
+					diag.Message("", "Expected an H1 in markdown for resource %v"), rawname)
 			}
 			sublines := strings.Split(subparts[1], "\n")
 			ret.Description += strings.Join(sublines[2:], "\n")


### PR DESCRIPTION
When parsing the header section of a documentation page, we were previously splitting by "\n# " to find H1 tags represented in Markdown. Unfortunately, this co-incides with the comment marker in HCL code inside code fences, and we do not track code fence contexts.

While a better fix for this would be to parse code fences and ignore their contents, it should be sufficient to take the first H1 element as the resource name and leave any subsequent ones in the section alone - assuming they are comments - by using `strings.SplitN` with `n = 2` instead of an unbounded split.

If no H1 lines appear, we still emit a warning as this is not expected. A notable example of this class of spurious warning is `aws_vpc_peering_connection_options` which has code comments inside fenced
blocks in the description.