### PR TITLE
Accept CustomResourceOptions in `get` methods

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -439,6 +439,7 @@ func (g *nodeJSGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType
 	w.Writefmtln("}")
 }
 
+//nolint:lll
 func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (string, error) {
 	// Create a resource module file into which all of this resource's types will go.
 	name := res.name

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -481,8 +481,8 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		w.Writefmtln("     * @param id The _unique_ provider ID of the resource to lookup.")
 		w.Writefmtln("     * @param state Any extra arguments used during the lookup.")
 		w.Writefmtln("     */")
-		w.Writefmtln("    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: %s): %s {", stateType, name)
-		w.Writefmtln("        return new %s(name, <any>state, { id });", name)
+		w.Writefmtln("    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: %s, opts?: pulumi.CustomResourceOptions): %s {", stateType, name)
+		w.Writefmtln("        return new %s(name, <any>state, { ...opts, id: id });", name)
 		w.Writefmtln("    }")
 		w.Writefmtln("")
 	}


### PR DESCRIPTION
This is necessary in order to use first-class providers with these
methods.

Fixes #289.