### PR TITLE
Fix default properties for Python

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -456,7 +456,8 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 
 		// Fill in computed defaults for arguments.
 		if defaultValue := pyDefaultValue(prop); defaultValue != "" {
-			w.Writefmtln("        %s = %s", pname, defaultValue)
+			w.Writefmtln("        if not %s:", pname)
+			w.Writefmtln("            %s = %s", pname, defaultValue)
 		}
 
 		// Check that required arguments are present.


### PR DESCRIPTION
Instead of always overlaying defaults on top of user-supplied values,
only supply the default if the user did not supply a value.

Fixes https://github.com/pulumi/pulumi-terraform/issues/271.