### PR TITLE
Stop cleaning Terraform schema in tfbridge

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -177,7 +177,7 @@ func NewProvider(ctx context.Context, host *provider.HostClient, module string, 
 		version: version,
 		tf:      tf,
 		info:    info,
-		config:  CleanTerraformSchema(tf.Schema),
+		config:  tf.Schema,
 	}
 	p.setLoggingContext(ctx)
 	p.initResourceMaps()
@@ -230,11 +230,8 @@ func (p *Provider) initResourceMaps() {
 			tok = tokens.Type(string(p.pkg()) + ":" + camelName + ":" + pascalName)
 		}
 
-		tfres := p.tf.ResourcesMap[res.Name]
-		tfres.Schema = CleanTerraformSchema(tfres.Schema)
-
 		p.resources[tok] = Resource{
-			TF:     tfres,
+			TF:     p.tf.ResourcesMap[res.Name],
 			TFName: res.Name,
 			Schema: schema,
 		}
@@ -261,11 +258,8 @@ func (p *Provider) initResourceMaps() {
 			tok = tokens.ModuleMember(string(p.baseDataMod()) + ":" + camelName)
 		}
 
-		tfres := p.tf.DataSourcesMap[ds.Name]
-		tfres.Schema = CleanTerraformSchema(tfres.Schema)
-
 		p.dataSources[tok] = DataSource{
-			TF:     tfres,
+			TF:     p.tf.DataSourcesMap[ds.Name],
 			TFName: ds.Name,
 			Schema: schema,
 		}


### PR DESCRIPTION
Cleaning the Terraform schema using CleanTerraformSchema results in properties which are marked Removed by the schema definition being actually removed. Such properties can be set by CRUD methods for a Terraform resource, however, so we can't just remove them.

By not cleaning in tfbridge but still retaining the calls to Clean in tfgen, we should remove the class of errors seen in pulumi/pulumi-gcp#79. This approach does mean that items which are Removed but still set are saved in state, but that is not likely to present an issue.

An alternative is to filter the removed fields _after_ the call to the Terraform provider but before returning the new state to the engine - though this could present issues if a removed field is used as an input. We aren't aware of cases where this happens, but cannot necessarily rule it out.