### PR TITLE
Update pulumi/pulumi dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,7 +412,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "0e868f15fc3aad99ac77eca29f8c0600a27b5ae3"
+  revision = "a02bfb64696d90bc8a5491b718f1f6853f041e24"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Pick up the fix for https://github.com/pulumi/pulumi/pull/2368. At a
minimum, this version of pulumi/pulumi needs to flow to each of our
tf-bridged providers, and it seems like because of that we should also
update our reference here.