### PR TITLE
Fix missing examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
+    - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies
 after_failure:


### PR DESCRIPTION
The prior logic for skipping examples when a tf2pulumi failure
was encountered wasn't quite right. It meant that we'd clear out
the buffer for an *entire* run of examples, when it was just one
of them that failed. This led to lots of missing examples (e.g.,
S3 buckets only had 1, whereas after this fix, there are 6).
Furthermore, since we only retained the "last" ones that succeeded,
it meant that we were missing the more basic examples, since they
often come "first." The new logic simply skips the affected example
as determined by the presence of '##'-style MarkDown delimiters.

Fixes pulumi/pulumi-terraform#311.