### PR TITLE
Replace Windows newlines in Markdown

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -196,6 +196,9 @@ func parseTFMarkdown(language language, kind DocKind, markdown string,
 		URL:        fmt.Sprintf(terraformDocsTemplate, provider, kind, withoutPackageName(provider, rawname)),
 	}
 
+	// Replace any Windows-style newlines.
+	markdown = strings.Replace(markdown, "\r\n", "\n", -1)
+
 	// Split the sections by H2 topics in the MarkDown file.
 	for _, section := range splitGroupLines(markdown, "## ") {
 		// Extract the header name, since this will drive how we process the content.


### PR DESCRIPTION
A surprising number of docs files contain Windows line endings, rather
than UNIX line endings, which confuses our newline-splitting parsing.
The result is lots of unparsed content in the frontmatter for resources,
not to mention apparently "missing" property documentation.

This fix simply normalizes such line endings before parsing.