### PR TITLE
Emit correct presence checks for required props

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -464,13 +464,13 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 
 		// Fill in computed defaults for arguments.
 		if defaultValue := pyDefaultValue(prop); defaultValue != "" {
-			w.Writefmtln("        if not %s:", pname)
+			w.Writefmtln("        if %s is None:", pname)
 			w.Writefmtln("            %s = %s", pname, defaultValue)
 		}
 
 		// Check that required arguments are present.
 		if !prop.optional() {
-			w.Writefmtln("        if not %s:", pname)
+			w.Writefmtln("        if %s is None:", pname)
 			w.Writefmtln("            raise TypeError('Missing required property %s')", pname)
 		}
 


### PR DESCRIPTION
Coercing a value to a boolean is not enough to determine whether a
property was provided in Python - it may have been provided, but it may
be a value that Python does not consider to be truthy, such as the
number zero.

This commit tests properties explicitly against None (their Python
default value) to check and see if they have been provided.