### PR TITLE
Optionally elide name properties from examples

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -58,7 +58,7 @@ const (
 // getDocsForProvider extracts documentation details for the given package from
 // TF website documentation markdown content
 func getDocsForProvider(language language, provider string, kind DocKind,
-	rawname string, docinfo *tfbridge.DocInfo) (parsedDoc, error) {
+	rawname, autoNameProperty string, docinfo *tfbridge.DocInfo) (parsedDoc, error) {
 	repo, err := getRepoDir(provider)
 	if err != nil {
 		return parsedDoc{}, err
@@ -85,14 +85,14 @@ func getDocsForProvider(language language, provider string, kind DocKind,
 		return parsedDoc{}, nil
 	}
 
-	doc, err := parseTFMarkdown(language, kind, string(markdownByts), provider, rawname)
+	doc, err := parseTFMarkdown(language, kind, string(markdownByts), provider, rawname, autoNameProperty)
 	if err != nil {
 		return parsedDoc{}, nil
 	}
 
 	if docinfo != nil {
 		// Merge Attributes from source into target
-		if err := mergeDocs(language, provider, kind, doc.Attributes, docinfo.IncludeAttributesFrom,
+		if err := mergeDocs(language, provider, kind, doc.Attributes, docinfo.IncludeAttributesFrom, autoNameProperty,
 			func(s parsedDoc) map[string]string {
 				return s.Attributes
 			},
@@ -102,7 +102,7 @@ func getDocsForProvider(language language, provider string, kind DocKind,
 
 		// Merge Arguments from source into Attributes of target
 		if err := mergeDocs(language, provider, kind, doc.Attributes, docinfo.IncludeAttributesFromArguments,
-			func(s parsedDoc) map[string]string {
+			autoNameProperty, func(s parsedDoc) map[string]string {
 				return s.Arguments
 			},
 		); err != nil {
@@ -110,7 +110,7 @@ func getDocsForProvider(language language, provider string, kind DocKind,
 		}
 
 		// Merge Arguments from source into target
-		if err := mergeDocs(language, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom,
+		if err := mergeDocs(language, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom, autoNameProperty,
 			func(s parsedDoc) map[string]string {
 				return s.Arguments
 			},
@@ -137,11 +137,11 @@ func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte
 }
 
 // mergeDocs adds the docs specified by extractDoc from sourceFrom into the targetDocs
-func mergeDocs(language language, provider string, kind DocKind, targetDocs map[string]string, sourceFrom string,
-	extractDocs func(d parsedDoc) map[string]string) error {
+func mergeDocs(language language, provider string, kind DocKind, targetDocs map[string]string, sourceFrom,
+	autoNameProperty string, extractDocs func(d parsedDoc) map[string]string) error {
 
 	if sourceFrom != "" {
-		sourceDocs, err := getDocsForProvider(language, provider, kind, sourceFrom, nil)
+		sourceDocs, err := getDocsForProvider(language, provider, kind, sourceFrom, autoNameProperty, nil)
 		if err != nil {
 			return err
 		}
@@ -188,8 +188,8 @@ func splitGroupLines(s, sep string) [][]string {
 
 // parseTFMarkdown takes a TF website markdown doc and extracts a structured representation for use in
 // generating doc comments
-func parseTFMarkdown(language language, kind DocKind, markdown string,
-	provider string, rawname string) (parsedDoc, error) {
+func parseTFMarkdown(language language, kind DocKind, markdown, provider, rawname,
+	autoNameProperty string) (parsedDoc, error) {
 	ret := parsedDoc{
 		Arguments:  make(map[string]string),
 		Attributes: make(map[string]string),
@@ -261,7 +261,7 @@ func parseTFMarkdown(language language, kind DocKind, markdown string,
 			// bail out, but most errors are ignorable and just lead to us skipping one section.
 			var skippableExamples bool
 			var err error
-			subsection, skippableExamples, err = parseExamples(language, subsection)
+			subsection, skippableExamples, err = parseExamples(language, subsection, autoNameProperty)
 			if err != nil {
 				return parsedDoc{}, err
 			} else if skippableExamples && !headerIsArgsReference &&
@@ -424,7 +424,7 @@ func printDocStats(printIgnoreDetails, printHCLFailureDetails bool) {
 // parseExamples converts an examples section into code comments, including converting any code snippets.
 // If an error converting a code example occurs, the bool (skip) will be true. If a fatal error occurs, the
 // error returned will be non-nil.
-func parseExamples(language language, lines []string) ([]string, bool, error) {
+func parseExamples(language language, lines []string, autoNameProperty string) ([]string, bool, error) {
 	// Each `Example ...` section contains one or more examples written in HCL, optionally separated by
 	// comments about the examples. We will attempt to convert them using our `tf2pulumi` tool, and append
 	// them to the description. If we can't, we'll simply log a warning and keep moving along.
@@ -440,7 +440,7 @@ func parseExamples(language language, lines []string) ([]string, bool, error) {
 					cline := lines[i]
 					if strings.Index(cline, "```") == 0 {
 						// We've got some code -- assume it's HCL and try to convert it.
-						code, stderr, err := convertHCL(hcl)
+						code, stderr, err := convertHCL(hcl, autoNameProperty)
 						if err != nil {
 							// If the conversion failed, there are two cases to consider. First, if tf2pulumi was
 							// missing from the path, we want to error eagerly, as that means the user probably
@@ -498,7 +498,7 @@ var errTF2PulumiMissing = errors.New("tf2pulumi is missing, please install it an
 
 // convertHCL converts an in-memory, simple HCL program to Pulumi, and returns it as a string. In the event
 // of failure, the error returned will be non-nil, and the second string contains the stderr stream of details.
-func convertHCL(hcl string) (string, string, error) {
+func convertHCL(hcl, autoNameProperty string) (string, string, error) {
 	// First, see if tf2pulumi is on the PATH, or not.
 	path, err := exec.LookPath("tf2pulumi")
 	if err != nil {
@@ -521,7 +521,13 @@ func convertHCL(hcl string) (string, string, error) {
 	// tf2pulumi in library form because it greatly complicates our modules/vendoring story.
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	tf2pulumi := exec.Command(path, "--allow-missing-variables")
+
+	args := []string{"--allow-missing-variables"}
+	if autoNameProperty != "" {
+		args = append(args, "--filter-resource-names="+autoNameProperty)
+	}
+
+	tf2pulumi := exec.Command(path, args...)
 	tf2pulumi.Dir = dir
 	tf2pulumi.Stdout = stdout
 	tf2pulumi.Stderr = stderr

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -52,6 +52,7 @@ type generator struct {
 	lg          langGenerator         // the generator with language-specific understanding.
 	overlaysDir string                // the directory in which source overlays come from.
 	outDir      string                // the directory in which to generate the code.
+	autoName    string                // the default autoname property for this package's resources, if any.
 }
 
 type language string
@@ -302,7 +303,7 @@ type plainOldType struct {
 
 // newGenerator returns a code-generator for the given language runtime and package info.
 func newGenerator(pkg, version string, language language, info tfbridge.ProviderInfo,
-	overlaysDir, outDir string) (*generator, error) {
+	overlaysDir, outDir, autoNameProperty string) (*generator, error) {
 	// If outDir or overlaysDir are empty, default to pack/<language>/ and overlays/<language>/ in the pwd.
 	if outDir == "" || overlaysDir == "" {
 		p, err := os.Getwd()
@@ -338,6 +339,7 @@ func newGenerator(pkg, version string, language language, info tfbridge.Provider
 		lg:          lg,
 		overlaysDir: overlaysDir,
 		outDir:      outDir,
+		autoName:    autoNameProperty,
 	}, nil
 }
 
@@ -534,7 +536,7 @@ func (g *generator) gatherResource(rawname string,
 	// Collect documentation information
 	var parsedDocs parsedDoc
 	if !isProvider {
-		pd, err := getDocsForProvider(g.language, g.info.Name, ResourceDocs, rawname, info.Docs)
+		pd, err := getDocsForProvider(g.language, g.info.Name, ResourceDocs, rawname, g.autoName, info.Docs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -687,7 +689,7 @@ func (g *generator) gatherDataSource(rawname string,
 	name, module := dataSourceName(g.info.Name, rawname, info)
 
 	// Collect documentation information for this data source.
-	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, DataSourceDocs, rawname, info.Docs)
+	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, DataSourceDocs, rawname, g.autoName, info.Docs)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -41,6 +41,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 	var overlaysDir string
 	var quiet bool
 	var verbose int
+	var autoNameProperty string
 	cmd := &cobra.Command{
 		Use:   os.Args[0] + " <LANGUAGE>",
 		Args:  cmdutil.SpecificArgs([]string{"language"}),
@@ -57,7 +58,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 			"provider plugin is metadata-driven and thus works against all Terraform providers.\n",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Create a generator with the specified settings.
-			g, err := newGenerator(pkg, version, language(args[0]), prov, overlaysDir, outDir)
+			g, err := newGenerator(pkg, version, language(args[0]), prov, overlaysDir, outDir, autoNameProperty)
 			if err != nil {
 				return err
 			}
@@ -85,6 +86,8 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 		&quiet, "quiet", "q", false, "Suppress non-error output progress messages")
 	cmd.PersistentFlags().IntVarP(
 		&verbose, "verbose", "v", 0, "Enable verbose logging (e.g., v=3); anything >3 is very verbose")
+	cmd.PersistentFlags().StringVar(
+		&autoNameProperty, "autoname", "name", "Strip the indicated auto-name property when generating examples")
 
 	return cmd
 }


### PR DESCRIPTION
For most TF-based providers, we have a fairly regular pattern of
auto-generating values for resource names if they are not specified.
This helps avoid collisions between resources, and increases the chance
that copy-pasted code will deploy successfully. These changes ask
`tf2pulumi` to strip any values for autoname properties from its output
when generating examples.