### PR TITLE
Fix a nil dereference.

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -801,7 +801,7 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 
 		// Add the special "id" attribute if it wasn't listed in the schema
 		props := MakeTerraformResult(invoke, ds.TF.Schema, ds.Schema.Fields)
-		if _, has := props["id"]; !has {
+		if _, has := props["id"]; !has && invoke != nil {
 			props["id"] = resource.NewStringProperty(invoke.ID)
 		}
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -412,7 +412,7 @@ func MakeTerraformResult(state *terraform.InstanceState,
 	outMap := MakeTerraformOutputs(outs, tfs, ps, nil, false)
 
 	// If there is any Terraform metadata associated with this state, record it.
-	if len(state.Meta) != 0 {
+	if state != nil && len(state.Meta) != 0 {
 		metaJSON, err := json.Marshal(state.Meta)
 		contract.Assert(err == nil)
 		outMap[metaKey] = resource.NewStringProperty(string(metaJSON))


### PR DESCRIPTION
If `state` is `nil`, don't attempt to look at the value of `state.Meta`.

Fixes #323.