### PR TITLE
Fall back to the schema type for strings

### DIFF
--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -865,3 +865,29 @@ func makeTestTFProvider(schemaMap map[string]*schema.Schema, importer schema.Sta
 		},
 	}
 }
+
+func TestStringOutputsWithSchema(t *testing.T) {
+	result := MakeTerraformOutputs(
+		map[string]interface{}{
+			"bool_property_value":      "false",
+			"number_property_value":    "42",
+			"float_property_value":     "42.0",
+			"no_schema_property_value": "42",
+		},
+		map[string]*schema.Schema{
+			"bool_property_value":   {Type: schema.TypeBool},
+			"number_property_value": {Type: schema.TypeInt},
+			"float_property_value":  {Type: schema.TypeFloat},
+		},
+		map[string]*SchemaInfo{},
+		nil,   /* assets */
+		false, /* useRawNames */
+	)
+
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"boolPropertyValue":     false,
+		"numberPropertyValue":   42,
+		"floatPropertyValue":    42.0,
+		"noSchemaPropertyValue": "42",
+	}), result)
+}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -873,11 +873,17 @@ func TestStringOutputsWithSchema(t *testing.T) {
 			"number_property_value":    "42",
 			"float_property_value":     "42.0",
 			"no_schema_property_value": "42",
+			"not_an_int_value":         "lmao",
+			"not_a_bool_value":         "lmao2",
+			"not_a_float_value":        "lmao3",
 		},
 		map[string]*schema.Schema{
 			"bool_property_value":   {Type: schema.TypeBool},
 			"number_property_value": {Type: schema.TypeInt},
 			"float_property_value":  {Type: schema.TypeFloat},
+			"not_an_int_value":      {Type: schema.TypeInt},
+			"not_a_bool_value":      {Type: schema.TypeBool},
+			"not_a_float_value":     {Type: schema.TypeFloat},
 		},
 		map[string]*SchemaInfo{},
 		nil,   /* assets */
@@ -889,5 +895,8 @@ func TestStringOutputsWithSchema(t *testing.T) {
 		"numberPropertyValue":   42,
 		"floatPropertyValue":    42.0,
 		"noSchemaPropertyValue": "42",
+		"notAnIntValue":         "lmao",
+		"notABoolValue":         "lmao2",
+		"notAFloatValue":        "lmao3",
 	}), result)
 }


### PR DESCRIPTION
Terraform occasionally sends back strings for fields whose schema type
indicates that they are not strings. If this is the case, convert the
string to the requested primitive instead of returning the string
verbatim.

This fixes a variety of type errors that can occur when using resource
outputs in strongly typed languages.