### PR TITLE
Omit Sphinx documentation pragma if empty

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -851,7 +851,6 @@ func (g *pythonGenerator) emitInitDocstring(w *tools.GenWriter, mod *module, res
 		name := pyName(prop.name)
 		ty := pyType(prop)
 		if prop.doc == "" {
-			fmt.Fprintf(&buf, ":param pulumi.Input[%s] %s\n", ty, name)
 			continue
 		}
 


### PR DESCRIPTION
If a property doesn't have any documentation, skip generating a :param
directive. Generating a :param directive without documentation confuses
Sphinx and messes up Sphinx's documentation output. Instead of
generating an empty :param pragma, this commit skips emitting it
altogether if documentation can't be found.

Fixes https://github.com/pulumi/pulumi-terraform/issues/326.