### PR TITLE
Use Python name to refer to submodules in __all__

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -231,7 +231,7 @@ func (g *pythonGenerator) emitIndex(mod *module, exports, submods []string) erro
 			if i > 0 {
 				w.Writefmt(", ")
 			}
-			w.Writefmt("'%s'", sub)
+			w.Writefmt("'%s'", pyName(sub))
 		}
 		w.Writefmtln("]")
 	}
@@ -243,7 +243,7 @@ func (g *pythonGenerator) emitIndex(mod *module, exports, submods []string) erro
 		}
 		w.Writefmtln("# Export this package's modules as members:")
 		for _, exp := range exports {
-			w.Writefmtln("from .%s import *", exp)
+			w.Writefmtln("from .%s import *", pyName(exp))
 		}
 	}
 


### PR DESCRIPTION
Prior to this commit we were using a module's Pulumi name in __all__,
which is supposed to list the full set of submodules contained within a
module. Unfortunately this did not correspond to the on-disk module
format, which is a Python name (camel-cased), and thus it was impossible
to import this module.

This commit fixes the issue by using the Python name to refer to
submodules when generating __all__.

Fixes https://github.com/pulumi/pulumi-terraform/issues/327.