### PR TITLE
Elide autoname properties in examples

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -344,6 +344,7 @@ func (m *MarshallableSchemaInfo) Unmarshal() *SchemaInfo {
 		Elem:        m.Elem.Unmarshal(),
 		Fields:      fields,
 		Asset:       m.Asset,
+		Default:     m.Default.Unmarshal(),
 		MaxItemsOne: m.MaxItemsOne,
 	}
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -52,7 +52,6 @@ type generator struct {
 	lg          langGenerator         // the generator with language-specific understanding.
 	overlaysDir string                // the directory in which source overlays come from.
 	outDir      string                // the directory in which to generate the code.
-	autoName    string                // the default autoname property for this package's resources, if any.
 }
 
 type language string
@@ -303,7 +302,7 @@ type plainOldType struct {
 
 // newGenerator returns a code-generator for the given language runtime and package info.
 func newGenerator(pkg, version string, language language, info tfbridge.ProviderInfo,
-	overlaysDir, outDir, autoNameProperty string) (*generator, error) {
+	overlaysDir, outDir string) (*generator, error) {
 	// If outDir or overlaysDir are empty, default to pack/<language>/ and overlays/<language>/ in the pwd.
 	if outDir == "" || overlaysDir == "" {
 		p, err := os.Getwd()
@@ -339,7 +338,6 @@ func newGenerator(pkg, version string, language language, info tfbridge.Provider
 		lg:          lg,
 		overlaysDir: overlaysDir,
 		outDir:      outDir,
-		autoName:    autoNameProperty,
 	}, nil
 }
 
@@ -536,7 +534,7 @@ func (g *generator) gatherResource(rawname string,
 	// Collect documentation information
 	var parsedDocs parsedDoc
 	if !isProvider {
-		pd, err := getDocsForProvider(g.language, g.info.Name, ResourceDocs, rawname, g.autoName, info.Docs)
+		pd, err := getDocsForProvider(g.language, g.info.Name, ResourceDocs, rawname, info.Docs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -689,7 +687,7 @@ func (g *generator) gatherDataSource(rawname string,
 	name, module := dataSourceName(g.info.Name, rawname, info)
 
 	// Collect documentation information for this data source.
-	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, DataSourceDocs, rawname, g.autoName, info.Docs)
+	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, DataSourceDocs, rawname, info.Docs)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -41,7 +41,6 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 	var overlaysDir string
 	var quiet bool
 	var verbose int
-	var autoNameProperty string
 	cmd := &cobra.Command{
 		Use:   os.Args[0] + " <LANGUAGE>",
 		Args:  cmdutil.SpecificArgs([]string{"language"}),
@@ -58,7 +57,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 			"provider plugin is metadata-driven and thus works against all Terraform providers.\n",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Create a generator with the specified settings.
-			g, err := newGenerator(pkg, version, language(args[0]), prov, overlaysDir, outDir, autoNameProperty)
+			g, err := newGenerator(pkg, version, language(args[0]), prov, overlaysDir, outDir)
 			if err != nil {
 				return err
 			}
@@ -86,8 +85,6 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 		&quiet, "quiet", "q", false, "Suppress non-error output progress messages")
 	cmd.PersistentFlags().IntVarP(
 		&verbose, "verbose", "v", 0, "Enable verbose logging (e.g., v=3); anything >3 is very verbose")
-	cmd.PersistentFlags().StringVar(
-		&autoNameProperty, "autoname", "name", "Strip the indicated auto-name property when generating examples")
 
 	return cmd
 }


### PR DESCRIPTION
Use the new autoname elision in `tf2pulumi` to elide auto-named
properties in examples.