### PR TITLE
Adopt changes to Read and Diff

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -873,6 +873,7 @@
     "github.com/stretchr/testify/assert",
     "golang.org/x/net/context",
     "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/status",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -161,6 +161,14 @@
   version = "v1.32.0"
 
 [[projects]]
+  digest = "1:ac02823572830fb544c7a94152465ca7833aaf1f186aeb4445ce9d34aacfcc4a"
+  name = "github.com/gofrs/flock"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7f43ea2e6a643ad441fc12d0ecc0d3388b300c53"
+  version = "v0.7.0"
+
+[[projects]]
   branch = "master"
   digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
@@ -487,7 +495,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d9577b764ea67e82960048873262d31c81a860276c7ebb28da1956c34759e557"
+  digest = "1:7090d1d6bbf1a323e34810752ab4b979c405d3688b7a93e0edf4cd38dc455a3a"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/diag",
@@ -514,7 +522,7 @@
     "sdk/proto/go",
   ]
   pruneopts = ""
-  revision = "a02bfb64696d90bc8a5491b718f1f6853f041e24"
+  revision = "905e7353e4ce6f92e417a56fb29cb433a9577b9d"
 
 [[projects]]
   branch = "master"

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -842,3 +842,21 @@ func CoerceTerraformString(schType schema.ValueType, stringValue string) (interf
 	// Else it's just a string.
 	return stringValue, nil
 }
+
+func extractInputsFromOutputs(urn resource.URN, outs resource.PropertyMap,
+	tfs map[string]*schema.Schema, ps map[string]*SchemaInfo) (resource.PropertyMap, error) {
+
+	inputs := make(resource.PropertyMap)
+	for name, value := range outs {
+		// If this property is not an input, ignore it.
+		_, sch, _ := getInfoFromPulumiName(name, tfs, ps, false)
+		if sch == nil || (!sch.Optional && !sch.Required) {
+			continue
+		}
+
+		// Otherwise, copy it to the result.
+		inputs[name] = value
+	}
+
+	return inputs, nil
+}


### PR DESCRIPTION
1. Return resource inputs as well as resource state from Read()
2. Return a list of properties that changed from Diff()

The approach taken for (1) is very straightforward: any property that we
recognize as an input (i.e. it is either Required or Optional) is copied
to the input bag. Strictly speaking, this is an overestimate of the
necessary input set: some Optional properties may also be Computed, in
which case they may have been set by the provider itself and thus would
not be part of the user-specified input set.

(2) is very straightforward: the changed property names are simply
collected while we are looking for RequiresNew diffs. The names of the
returned properties have been fixed so that they only refer to top-level
properties and are properly converted to Pulumi names. This is necessary
in order for the engine (and the user) to make sense of the names.

The engine takes advantage of (2) to provide a good experience when (1)
overestimates the input set. Normally, such an overestimate could result
in a large number of spurious diffs presented to the user. Generally
speaking, though, TF considers the removal of an Optional Computed
property to be a no-diff change; filtering the diffs that are displayed
to only those indicated by the provider removes these spurious diffs.