### PR TITLE
Allow ResourcePrefix to be different to Name

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -24,21 +24,33 @@ import (
 // ProviderInfo contains information about a Terraform provider plugin that we will use to generate the Pulumi
 // metadata.  It primarily contains a pointer to the Terraform schema, but can also contain specific name translations.
 type ProviderInfo struct {
-	P           *schema.Provider           // the TF provider/schema.
-	Name        string                     // the TF provider name (e.g. terraform-provider-XXXX).
-	Description string                     // an optional descriptive overview of the package (a default will be given).
-	Keywords    []string                   // an optional list of keywords to help discovery of this package.
-	License     string                     // the license, if any, the resulting package has (default is none).
-	Homepage    string                     // the URL to the project homepage.
-	Repository  string                     // the URL to the project source code repository.
-	Config      map[string]*SchemaInfo     // a map of TF name to config schema overrides.
-	Resources   map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
-	JavaScript  *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
-	Python      *PythonInfo                // optional overlay information for augmented Python code-generation.
-	Golang      *GolangInfo                // optional overlay information for augmented Golang code-generation.
+	P              *schema.Provider           // the TF provider/schema.
+	Name           string                     // the TF provider name (e.g. terraform-provider-XXXX).
+	ResourcePrefix string                     // the prefix on resources the provider exposes, if different to `Name`.
+	Description    string                     // an optional descriptive overview of the package (a default will be given).
+	Keywords       []string                   // an optional list of keywords to help discovery of this package.
+	License        string                     // the license, if any, the resulting package has (default is none).
+	Homepage       string                     // the URL to the project homepage.
+	Repository     string                     // the URL to the project source code repository.
+	Config         map[string]*SchemaInfo     // a map of TF name to config schema overrides.
+	Resources      map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
+	DataSources    map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
+	JavaScript     *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
+	Python         *PythonInfo                // optional overlay information for augmented Python code-generation.
+	Golang         *GolangInfo                // optional overlay information for augmented Golang code-generation.
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
+}
+
+// GetResourcePrefix returns the resource prefix for the provider: info.ResourcePrefix
+// if that is set, or info.Name if not. This is to avoid unexpected behaviour with providers
+// which have no need to set ResourcePrefix following its introduction.
+func (info ProviderInfo) GetResourcePrefix() string {
+	if info.ResourcePrefix == "" {
+		return info.Name
+	}
+
+	return info.ResourcePrefix
 }
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -534,7 +534,7 @@ func (g *generator) gatherResource(rawname string,
 	// Collect documentation information
 	var parsedDocs parsedDoc
 	if !isProvider {
-		pd, err := getDocsForProvider(g.language, g.info.Name, ResourceDocs, rawname, info.Docs)
+		pd, err := getDocsForProvider(g.language, g.info.Name, g.info.GetResourcePrefix(), ResourceDocs, rawname, info.Docs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -687,7 +687,8 @@ func (g *generator) gatherDataSource(rawname string,
 	name, module := dataSourceName(g.info.Name, rawname, info)
 
 	// Collect documentation information for this data source.
-	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, DataSourceDocs, rawname, info.Docs)
+	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, g.info.GetResourcePrefix(), DataSourceDocs,
+		rawname, info.Docs)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Some Terraform providers have a different name to the prefix on all of the resources - for example the Google Beta provider is named `google-beta`, but all of the resources have the prefix `google`. Previously, this caused documentation generation to fail - we can resolve that by introducing a separate ResourcePrefix member on ProviderInfo, and using that if it is set.

Marked as P1 since it blocks the Google Beta provider which is also P1.