### PR TITLE
Track default population in inputs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -495,7 +495,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7090d1d6bbf1a323e34810752ab4b979c405d3688b7a93e0edf4cd38dc455a3a"
+  digest = "1:83602cb5fbb57bc388f5c6e27e815c2faea6850f0722bb782067a5169de88fb2"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/diag",
@@ -522,7 +522,7 @@
     "sdk/proto/go",
   ]
   pruneopts = ""
-  revision = "905e7353e4ce6f92e417a56fb29cb433a9577b9d"
+  revision = "7ebd70a3e6e0e80485fd2212929fc2db8e380a08"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -858,6 +858,7 @@
     "github.com/hashicorp/terraform/helper/logging",
     "github.com/hashicorp/terraform/helper/schema",
     "github.com/hashicorp/terraform/terraform",
+    "github.com/mitchellh/copystructure",
     "github.com/pkg/errors",
     "github.com/pulumi/pulumi/pkg/diag",
     "github.com/pulumi/pulumi/pkg/resource",

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -657,7 +657,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			return nil, err
 		}
 
-		inputs, err := extractInputsFromOutputs(urn, props, res.TF.Schema, res.Schema.Fields)
+		inputs, err := extractInputsFromOutputs(nil, props, res.TF.Schema, res.Schema.Fields)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -622,7 +622,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 
 	// Manufacture Terraform attributes and state with the provided properties, in preparation for reading.
 	oldInputs, err := plugin.UnmarshalProperties(req.GetInputs(), plugin.MarshalOptions{
-		Label: fmt.Sprintf("%s.inputss", label), KeepUnknowns: true, SkipNulls: true})
+		Label: fmt.Sprintf("%s.inputs", label), KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -621,6 +621,11 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	glog.V(9).Infof("%s executing", label)
 
 	// Manufacture Terraform attributes and state with the provided properties, in preparation for reading.
+	oldInputs, err := plugin.UnmarshalProperties(req.GetInputs(), plugin.MarshalOptions{
+		Label: fmt.Sprintf("%s.inputss", label), KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
 	attrs, meta, err := MakeTerraformAttributesFromRPC(
 		res.TF, req.GetProperties(), res.TF.Schema, res.Schema.Fields, false, false, fmt.Sprintf("%s.state", label))
 	if err != nil {
@@ -657,7 +662,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			return nil, err
 		}
 
-		inputs, err := extractInputsFromOutputs(nil, props, res.TF.Schema, res.Schema.Fields)
+		inputs, err := extractInputsFromOutputs(oldInputs, props, res.TF.Schema, res.Schema.Fields)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -34,8 +34,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-// defaultsKey is the name of the property that is used in inputs and state to track which input property
-// values were populated with default values.
+// defaultsKey is the name of the input property that is used to track which property keys were populated using
+// default values from the resource's schema. This information is used to inform which input properties should be
+// populated using old defaults in subsequent updates. When populating the default value for an input property, the
+// property's old value will only be used as the default if the property's key is present in the defaults list for
+// the old property bag.
 const defaultsKey = "__defaults"
 
 // AssetTable is used to record which properties in a call to MakeTerraformInputs were assets so that they can be

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -27,11 +27,16 @@ import (
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/copystructure"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
+
+// defaultsKey is the name of the property that is used in inputs and state to track which input property
+// values were populated with default values.
+const defaultsKey = "__defaults"
 
 // AssetTable is used to record which properties in a call to MakeTerraformInputs were assets so that they can be
 // marshaled back to assets by MakeTerraformOutputs.
@@ -49,6 +54,12 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 	// Enumerate the inputs provided and add them to the map using their Terraform names.
 	for key, value := range news {
+		// If this is a reserved property, ignore it.
+		switch key {
+		case defaultsKey, metaKey:
+			continue
+		}
+
 		// First translate the Pulumi property name to a Terraform name.
 		name, tfi, psi := getInfoFromPulumiName(key, tfs, ps, useRawNames)
 		contract.Assert(name != "")
@@ -69,6 +80,20 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 	// Now enumerate and propagate defaults if the corresponding values are still missing.
 	if defaults {
+		// Create an array to track which properties are defaults.
+		newDefaults := []interface{}{}
+
+		// Pull the list of old defaults if any. If there is no list, then we will treat all old values as being usable
+		// for new defaults. If there is a list, we will only propagate defaults that were themselves defaults.
+		useOldDefault := func(name string) bool { return true }
+		if oldDefaults, ok := olds[defaultsKey]; ok {
+			oldDefaultSet := make(map[string]bool)
+			for _, k := range oldDefaults.ArrayValue() {
+				oldDefaultSet[k.StringValue()] = true
+			}
+			useOldDefault = func(key string) bool { return oldDefaultSet[key] }
+		}
+
 		// Compute any names for which setting a default would cause a conflict.
 		conflictsWith := make(map[string]struct{})
 		for name, sch := range tfs {
@@ -90,16 +115,18 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 			}
 
 			if _, has := result[name]; !has && info.HasDefault() {
+				var defaultValue interface{}
+				var source string
+
 				// If we already have a default value from a previous version of this resource, use that instead.
 				key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, useRawNames)
-				if old, hasold := olds[key]; hasold {
+				if old, hasold := olds[key]; hasold && useOldDefault(name) {
 					v, err := MakeTerraformInput(res, name, resource.PropertyValue{}, old, tfi, psi, assets,
 						false, useRawNames)
 					if err != nil {
 						return nil, err
 					}
-					result[name] = v
-					glog.V(9).Infof("Created Terraform input: %v = %v (old default)", key, old)
+					defaultValue, source = v, "old default"
 				} else if envVars := info.Default.EnvVars; len(envVars) != 0 {
 					v, err := schema.MultiEnvDefaultFunc(envVars, info.Default.Value)()
 					if err != nil {
@@ -136,20 +163,21 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 							return nil, errors.Errorf("unknown type for default value: %s", sch.Type)
 						}
 					}
-					if v != nil {
-						result[name] = v
-					}
-					glog.V(9).Infof("Created Terraform input: %v = %v (default from env vars)", name, result[name])
+					defaultValue, source = v, "env vars"
 				} else if info.Default.Value != nil {
-					result[name] = info.Default.Value
-					glog.V(9).Infof("Created Terraform input: %v = %v (default)", name, result[name])
+					defaultValue, source = info.Default.Value, "Pulumi schema"
 				} else if from := info.Default.From; from != nil {
 					v, err := from(res)
 					if err != nil {
 						return nil, err
 					}
-					result[name] = v
-					glog.V(9).Infof("Created Terraform input: %v = %v (default from fnc)", name, result[name])
+					defaultValue, source = v, "func"
+				}
+
+				if defaultValue != nil {
+					glog.V(9).Infof("Created Terraform input: %v = %v (from %s)", name, defaultValue, source)
+					result[name] = defaultValue
+					newDefaults = append(newDefaults, key)
 				}
 			}
 		}
@@ -167,6 +195,8 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 			}
 
 			if _, has := result[name]; !has {
+				var source string
+
 				// Check for a default value from Terraform. If there is not default from terraform, skip this name.
 				dv, err := sch.DefaultValue()
 				if err != nil {
@@ -177,20 +207,26 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 				// Next, if we already have a default value from a previous version of this resource, use that instead.
 				key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, useRawNames)
-				if old, hasold := olds[key]; hasold {
+				if old, hasold := olds[key]; hasold && useOldDefault(name) {
 					v, err := MakeTerraformInput(res, name, resource.PropertyValue{}, old, tfi, psi, assets,
 						false, useRawNames)
 					if err != nil {
 						return nil, err
 					}
-					result[name] = v
-					glog.V(9).Infof("Create Terraform input: %v = %v (old default)", name, old)
+					dv, source = v, "old default"
 				} else {
+					source = "Terraform schema"
+				}
+
+				if dv != nil {
+					glog.V(9).Infof("Created Terraform input: %v = %v (from %s)", name, dv, source)
 					result[name] = dv
-					glog.V(9).Infof("Created Terraform input: %v = %v (default from TF)", name, result[name])
+					newDefaults = append(newDefaults, key)
 				}
 			}
 		}
+
+		result[defaultsKey] = newDefaults
 	}
 
 	if glog.V(5) {
@@ -417,6 +453,7 @@ func MakeTerraformResult(state *terraform.InstanceState,
 		contract.Assert(err == nil)
 		outMap[metaKey] = resource.NewStringProperty(string(metaJSON))
 	}
+
 	return outMap
 }
 
@@ -578,7 +615,11 @@ func MakeTerraformConfigFromRPC(res *PulumiResource, m *pbstruct.Struct,
 	if err != nil {
 		return nil, err
 	}
-	return MakeTerraformConfig(res, props, tfs, ps, defaults)
+	cfg, err := MakeTerraformConfig(res, props, tfs, ps, defaults)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 // MakeTerraformConfigFromInputs creates a new Terraform configuration object from a set of Terraform inputs.
@@ -595,15 +636,14 @@ func MakeTerraformConfigFromInputs(inputs map[string]interface{}) (*terraform.Re
 func MakeTerraformAttributes(res *schema.Resource, m resource.PropertyMap, tfs map[string]*schema.Schema,
 	ps map[string]*SchemaInfo, defaults bool) (map[string]string, map[string]interface{}, error) {
 
-	// Strip out any metadata from the inputs.
+	// Parse out any metadata from the state.
 	var meta map[string]interface{}
 	if metaProperty, hasMeta := m[metaKey]; hasMeta && metaProperty.IsString() {
 		if err := json.Unmarshal([]byte(metaProperty.StringValue()), &meta); err != nil {
 			return nil, nil, err
 		}
-		delete(m, metaKey)
 	} else if res.SchemaVersion > 0 {
-		// If there was no metadata in the input and this resource has a non-zero schema version, return a meta bag
+		// If there was no metadata in the inputs and this resource has a non-zero schema version, return a meta bag
 		// with the current schema version. This helps avoid migration issues.
 		meta = map[string]interface{}{"schema_version": strconv.Itoa(res.SchemaVersion)}
 	}
@@ -843,7 +883,42 @@ func CoerceTerraformString(schType schema.ValueType, stringValue string) (interf
 	return stringValue, nil
 }
 
-func extractInputsFromOutputs(urn resource.URN, outs resource.PropertyMap,
+func propagateDefaultAnnotations(oldInput, newInput resource.PropertyValue) {
+	switch {
+	case oldInput.IsArray() && newInput.IsArray():
+		oldArray, newArray := oldInput.ArrayValue(), newInput.ArrayValue()
+		for i := range oldArray {
+			if i >= len(newArray) {
+				break
+			}
+			propagateDefaultAnnotations(oldArray[i], newArray[i])
+		}
+	case oldInput.IsObject() && newInput.IsObject():
+		oldMap, newMap := oldInput.ObjectValue(), newInput.ObjectValue()
+		for name, newValue := range newMap {
+			if oldValue, ok := oldMap[name]; ok {
+				propagateDefaultAnnotations(oldValue, newValue)
+			}
+		}
+
+		// If we have a list of inputs that were populated by defaults, filter out any properties that changed and add it
+		// to the new inputs.
+		newDefaultNames := []resource.PropertyValue{}
+		if oldDefaultNames, ok := oldMap[defaultsKey]; ok {
+			for _, nameValue := range oldDefaultNames.ArrayValue() {
+				name := resource.PropertyKey(nameValue.StringValue())
+				if oldMap[name].DeepEquals(newMap[name]) {
+					newDefaultNames = append(newDefaultNames, nameValue)
+				}
+			}
+		}
+		newMap[defaultsKey] = resource.NewArrayProperty(newDefaultNames)
+	default:
+		// nothing to do
+	}
+}
+
+func extractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
 	tfs map[string]*schema.Schema, ps map[string]*SchemaInfo) (resource.PropertyMap, error) {
 
 	inputs := make(resource.PropertyMap)
@@ -855,8 +930,15 @@ func extractInputsFromOutputs(urn resource.URN, outs resource.PropertyMap,
 		}
 
 		// Otherwise, copy it to the result.
-		inputs[name] = value
+		copy, err := copystructure.Copy(value)
+		if err != nil {
+			return nil, err
+		}
+		inputs[name] = copy.(resource.PropertyValue)
 	}
+
+	// Propagate default annotations.
+	propagateDefaultAnnotations(resource.NewObjectProperty(oldInputs), resource.NewObjectProperty(inputs))
 
 	return inputs, nil
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -17,16 +17,18 @@ package tfbridge
 import (
 	"context"
 	"os"
+	"sort"
 	"strconv"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
 )
@@ -570,6 +572,12 @@ func TestEmptyListAttribute(t *testing.T) {
 	})
 }
 
+func sortDefaultsList(m resource.PropertyMap) {
+	defs := m[defaultsKey].ArrayValue()
+	sort.Slice(defs, func(i, j int) bool { return defs[i].StringValue() < defs[j].StringValue() })
+	m[defaultsKey] = resource.NewArrayProperty(defs)
+}
+
 func TestDefaults(t *testing.T) {
 	// Produce maps with the following properties, and then validate them:
 	//     - aaa string; no defaults, no inputs => empty
@@ -587,7 +595,9 @@ func TestDefaults(t *testing.T) {
 	//     - iii string; old default "OLI", TF default "TFI", PS default "PSI", no input => "OLD"
 	//     - jjj string: old input "OLJ", no defaults, no input => no merged input
 	//     - lll: old default "OLL", TF default "TFL", no input => "OLL"
+	//     - ll2: old input "OLL", TF default "TFL", no input => "TL2"
 	//     - mmm: old default "OLM", PS default "PSM", no input => "OLM"
+	//     - mm2: old input "OLM", PS default "PM2", no input => "PM2"
 	//     - uuu: PS default "PSU", envvars w/o valiues => "PSU"
 	//     - vvv: PS default 42, envvars with values => 1337
 	//     - www: old default "OLW", deprecated, required, no input -> "OLW"
@@ -608,7 +618,9 @@ func TestDefaults(t *testing.T) {
 		"iii": {Type: schema.TypeString, Default: "TFI"},
 		"jjj": {Type: schema.TypeString},
 		"lll": {Type: schema.TypeString, Default: "TFL"},
+		"ll2": {Type: schema.TypeString, Default: "TL2"},
 		"mmm": {Type: schema.TypeString},
+		"mm2": {Type: schema.TypeString},
 		"sss": {Type: schema.TypeString, Removed: "removed"},
 		"ttt": {Type: schema.TypeString, Removed: "removed", Default: "TFD"},
 		"uuu": {Type: schema.TypeString},
@@ -627,6 +639,7 @@ func TestDefaults(t *testing.T) {
 		"hhh": {Default: &DefaultInfo{Value: "PSH"}},
 		"iii": {Default: &DefaultInfo{Value: "PSI"}},
 		"mmm": {Default: &DefaultInfo{Value: "PSM"}},
+		"mm2": {Default: &DefaultInfo{Value: "PM2"}},
 		"sss": {Default: &DefaultInfo{Value: "PSS"}},
 		"uuu": {Default: &DefaultInfo{Value: "PSU", EnvVars: []string{"PTFU", "PTFU2"}}},
 		"vvv": {Default: &DefaultInfo{Value: 42, EnvVars: []string{"PTFV", "PTFV2"}}},
@@ -634,10 +647,15 @@ func TestDefaults(t *testing.T) {
 		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
 	}
 	olds := resource.PropertyMap{
+		defaultsKey: resource.NewPropertyValue([]interface{}{
+			"iii", "jjj", "lll", "mmm", "www", "xxx",
+		}),
 		"iii": resource.NewStringProperty("OLI"),
 		"jjj": resource.NewStringProperty("OLJ"),
 		"lll": resource.NewStringProperty("OLL"),
+		"ll2": resource.NewStringProperty("OL2"),
 		"mmm": resource.NewStringProperty("OLM"),
+		"mm2": resource.NewStringProperty("OM2"),
 		"www": resource.NewStringProperty("OLW"),
 		"xxx": resource.NewStringProperty("OLX"),
 	}
@@ -653,7 +671,13 @@ func TestDefaults(t *testing.T) {
 	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
 	assert.NoError(t, err)
 	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false)
+
+	// sort the defaults list before the equality test below.
+	sortDefaultsList(outputs)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		defaultsKey: []interface{}{
+			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "uuu", "vvv", "www",
+		},
 		"bbb": "BBB",
 		"ccc": "CCC",
 		"cc2": "CC2",
@@ -667,7 +691,45 @@ func TestDefaults(t *testing.T) {
 		"hhh": "HHH",
 		"iii": "OLI",
 		"lll": "OLL",
+		"ll2": "TL2",
 		"mmm": "OLM",
+		"mm2": "PM2",
+		"uuu": "PSU",
+		"vvv": 1337,
+		"www": "OLW",
+		"zzz": asset,
+	}), outputs)
+
+	// Now delete the defaults list from the olds and re-run. This will affect the values for "ll2" and "mm2", which
+	// will be pulled from the old inputs instead of regenerated.
+	delete(olds, defaultsKey)
+	assets = make(AssetTable)
+	inputs, err = MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
+	assert.NoError(t, err)
+	outputs = MakeTerraformOutputs(inputs, tfs, ps, assets, false)
+
+	// sort the defaults list before the equality test below.
+	sortDefaultsList(outputs)
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		defaultsKey: []interface{}{
+			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "uuu", "vvv", "www",
+		},
+		"bbb": "BBB",
+		"ccc": "CCC",
+		"cc2": "CC2",
+		"ddd": "DDD",
+		"dd2": "DDD",
+		"eee": "EEE",
+		"ee2": "EE2",
+		"fff": "FFF",
+		"ff2": "FFF",
+		"ggg": "PSG",
+		"hhh": "HHH",
+		"iii": "OLI",
+		"lll": "OLL",
+		"ll2": "OL2",
+		"mmm": "OLM",
+		"mm2": "OM2",
 		"uuu": "PSU",
 		"vvv": 1337,
 		"www": "OLW",
@@ -687,7 +749,7 @@ func TestComputedAsset(t *testing.T) {
 	props := resource.PropertyMap{
 		"zzz": resource.NewStringProperty(config.UnknownVariableValue),
 	}
-	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
+	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, false, false)
 	assert.NoError(t, err)
 	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false)
 	assert.Equal(t, resource.PropertyMap{
@@ -707,7 +769,7 @@ func TestInvalidAsset(t *testing.T) {
 	props := resource.PropertyMap{
 		"zzz": resource.NewStringProperty("invalid"),
 	}
-	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, true, false)
+	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, false, false)
 	assert.NoError(t, err)
 	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false)
 	assert.Equal(t, resource.PropertyMap{
@@ -899,4 +961,98 @@ func TestStringOutputsWithSchema(t *testing.T) {
 		"notABoolValue":         "lmao2",
 		"notAFloatValue":        "lmao3",
 	}), result)
+}
+
+func TestExtractInputsFromOutputs(t *testing.T) {
+	tfProvider := makeTestTFProvider(
+		map[string]*schema.Schema{
+			"input_a": {Type: schema.TypeString, Required: true},
+			"input_b": {Type: schema.TypeString, Optional: true},
+			"inout_c": {Type: schema.TypeString, Optional: true, Computed: true},
+			"inout_d": {Type: schema.TypeString, Optional: true, Computed: true, Default: "inout_d_default"},
+			"input_e": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_a": {Type: schema.TypeString, Optional: true, Default: "field_a_default"},
+					},
+				},
+				MaxItems: 1,
+				Optional: true,
+			},
+			"input_f":  {Type: schema.TypeString, Required: true},
+			"output_g": {Type: schema.TypeString},
+		},
+		func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			return []*schema.ResourceData{d}, nil
+		})
+
+	tfres := tfProvider.ResourcesMap["importable_resource"]
+	tfres.Read = func(d *schema.ResourceData, meta interface{}) error {
+		if _, ok := d.GetOk("input_a"); !ok {
+			d.Set("input_a", "input_a_read")
+		}
+		if _, ok := d.GetOk("inout_c"); !ok {
+			d.Set("inout_c", "inout_c_read")
+		}
+		d.Set("inout_d", "inout_d_read")
+		d.Set("output_g", "output_g_read")
+		return nil
+	}
+	tfres.Create = func(d *schema.ResourceData, meta interface{}) error {
+		d.SetId("MyID")
+		if _, ok := d.GetOk("inout_c"); !ok {
+			d.Set("inout_c", "inout_c_create")
+		}
+		d.Set("output_g", "output_g_create")
+		return nil
+	}
+
+	p := &Provider{
+		tf: tfProvider,
+		resources: map[tokens.Type]Resource{
+			"importableResource": {
+				TF:     tfProvider.ResourcesMap["importable_resource"],
+				TFName: "importable_resource",
+				Schema: &ResourceInfo{
+					Tok: tokens.NewTypeToken("module", "importableResource"),
+					Fields: map[string]*SchemaInfo{
+						"input_f": {
+							Default: &DefaultInfo{
+								Value: "input_f_default",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	urn := resource.NewURN("s", "pr", "pa", "importableResource", "n")
+	id := resource.ID("MyID")
+
+	resp, err := p.Read(context.Background(), &pulumirpc.ReadRequest{
+		Id:  string(id),
+		Urn: string(urn),
+	})
+	assert.NoError(t, err)
+
+	outs, err := plugin.UnmarshalProperties(resp.GetProperties(), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"id":      "MyID",
+		"inputA":  "input_a_read",
+		"inoutC":  "inout_c_read",
+		"inoutD":  "inout_d_read",
+		"outputG": "output_g_read",
+	}), outs)
+
+	ins, err := plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		defaultsKey: []interface{}{},
+		"inputA":    "input_a_read",
+		"inoutC":    "inout_c_read",
+		"inoutD":    "inout_d_read",
+	}), ins)
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -994,6 +994,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 
 	tfres := tfProvider.ResourcesMap["importable_resource"]
 	tfres.Read = func(d *schema.ResourceData, meta interface{}) error {
+		_, ok := d.GetOk(defaultsKey)
+		assert.False(t, ok)
+
 		if _, ok := d.GetOk("input_a"); !ok {
 			set(d, "input_a", "input_a_read")
 		}
@@ -1005,6 +1008,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		return nil
 	}
 	tfres.Create = func(d *schema.ResourceData, meta interface{}) error {
+		_, ok := d.GetOk(defaultsKey)
+		assert.False(t, ok)
+
 		d.SetId("MyID")
 		if _, ok := d.GetOk("inout_c"); !ok {
 			set(d, "inout_c", "inout_c_create")


### PR DESCRIPTION
Add a reserved property to each map value present in an input bag that
tracks which keys in the map were populated using default values. When
performing default application, only use a value from an old input bag
if it was itself a default value.

This allows the following sequence of events:
- Create a resource with a value explicitly specified for property P
- Remove the value for property P and update the resource. The new value
  for property P will be whatever its default value is, if any.

Fixes https://github.com/pulumi/pulumi-aws/issues/439.