### PR TITLE
Insert _ between words and numbers during name mangling

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -34,6 +34,13 @@ func PulumiToTerraformName(name string, tfs map[string]*schema.Schema) string {
 				result += "_"
 			}
 			result += string(unicode.ToLower(c))
+		} else if c >= '0' && c <= '9' {
+			// If the last character is not a number, add a separator
+			lastChar := result[len(result)-1]
+			if lastChar < '0' || lastChar > '9' {
+				result += "_"
+			}
+			result += string(c)
 		} else {
 			result += string(c)
 		}

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -29,6 +29,7 @@ func TestPulumiToTerraformName(t *testing.T) {
 	assert.Equal(t, "test_name", PulumiToTerraformName("test_name", nil))
 	assert.Equal(t, "test_name_", PulumiToTerraformName("testName_", nil))
 	assert.Equal(t, "t_e_s_t_n_a_m_e", PulumiToTerraformName("TESTNAME", nil))
+	assert.Equal(t, "use_32_bit_worker_process", PulumiToTerraformName("use32BitWorkerProcess", nil))
 }
 
 func TestTerraformToPulumiName(t *testing.T) {
@@ -37,11 +38,13 @@ func TestTerraformToPulumiName(t *testing.T) {
 	assert.Equal(t, "testName", TerraformToPulumiName("test_name", nil, false))
 	assert.Equal(t, "testName_", TerraformToPulumiName("testName_", nil, false))
 	assert.Equal(t, "tESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, false))
+	assert.Equal(t, "use32BitWorkerProcess", TerraformToPulumiName("use_32_bit_worker_process", nil, false))
 	assert.Equal(t, "", TerraformToPulumiName("", nil, true))
 	assert.Equal(t, "Test", TerraformToPulumiName("test", nil, true))
 	assert.Equal(t, "TestName", TerraformToPulumiName("test_name", nil, true))
 	assert.Equal(t, "TestName_", TerraformToPulumiName("testName_", nil, true))
 	assert.Equal(t, "TESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, true))
+	assert.Equal(t, "Use32BitWorkerProcess", TerraformToPulumiName("use_32_bit_worker_process", nil, true))
 }
 
 func TestPluralize(t *testing.T) {


### PR DESCRIPTION
Fixes pulumi/pulumi-azure#157.

When applied to the Azure provider, this allows the following previously failing program to run to completion:

```typescript
import * as azure from "@pulumi/azure";

// Create an Azure Resource Group
const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {
    location: "West Europe",
});

const appServicePlan = new azure.appservice.Plan("test", {
    location: resourceGroup.location,
    resourceGroupName: resourceGroup.name,

    sku: {
        tier: "Standard",
        size: "S1"
    }
});

const appService = new azure.appservice.AppService("test", {
    location: resourceGroup.location,
    resourceGroupName: resourceGroup.name,
    appServicePlanId: appServicePlan.id,

    siteConfig: {
        dotnetFrameworkVersion: "v4.0",
        use32BitWorkerProcess: true,
        scmType: "LocalGit",
    },

    appSettings: {
        "SOMEKEY": "SomeValue",
    }
});
```

One thing that is unclear is whether this is correct in every case (i.e. whether Terraform providers are consistent with using underscores between words suffixed with numbers).