### PR TITLE
Project TypeInt as floats in python

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -890,9 +890,7 @@ func pyTypeFromSchema(sch *schema.Schema, info *tfbridge.SchemaInfo) string {
 	switch sch.Type {
 	case schema.TypeBool:
 		return "bool"
-	case schema.TypeInt:
-		return "int"
-	case schema.TypeFloat:
+	case schema.TypeInt, schema.TypeFloat:
 		return "float"
 	case schema.TypeString:
 		return "str"


### PR DESCRIPTION
Unlike JavaScript, Python clearly distinguishes between floats and
integers in their basic type hierarchy. Because the actual type of
values returned from tfbridge is always float, Python was observing that
fields whose schema type was TypeInt sometimes had float values, which
caused crashes and generally caused data sources to not behave well.

This fix causes tfgen to type all TypeInt fields as float, which has no
effect other than to change the type tests emitted by the return types
of data sources, which previously asserted that fields of type TypeInt
were literally of type int.