### PR TITLE
Allow bridging outside terraform-providers GH org

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -27,6 +27,7 @@ type ProviderInfo struct {
 	P              *schema.Provider           // the TF provider/schema.
 	Name           string                     // the TF provider name (e.g. terraform-provider-XXXX).
 	ResourcePrefix string                     // the prefix on resources the provider exposes, if different to `Name`.
+	GitHubOrg      string                     // the GitHub org of the provider. Defaults to `terraform-providers`.
 	Description    string                     // an optional descriptive overview of the package (a default will be given).
 	Keywords       []string                   // an optional list of keywords to help discovery of this package.
 	License        string                     // the license, if any, the resulting package has (default is none).
@@ -51,6 +52,14 @@ func (info ProviderInfo) GetResourcePrefix() string {
 	}
 
 	return info.ResourcePrefix
+}
+
+func (info ProviderInfo) GetGitHubOrg() string {
+	if info.GitHubOrg == "" {
+		return "terraform-providers"
+	}
+
+	return info.GitHubOrg
 }
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -57,9 +57,9 @@ const (
 
 // getDocsForProvider extracts documentation details for the given package from
 // TF website documentation markdown content
-func getDocsForProvider(language language, provider string, resourcePrefix string, kind DocKind,
+func getDocsForProvider(language language, org string, provider string, resourcePrefix string, kind DocKind,
 	rawname string, docinfo *tfbridge.DocInfo) (parsedDoc, error) {
-	repo, err := getRepoDir(provider)
+	repo, err := getRepoDir(org, provider)
 	if err != nil {
 		return parsedDoc{}, err
 	}
@@ -92,7 +92,7 @@ func getDocsForProvider(language language, provider string, resourcePrefix strin
 
 	if docinfo != nil {
 		// Merge Attributes from source into target
-		if err := mergeDocs(language, provider, resourcePrefix, kind, doc.Attributes, docinfo.IncludeAttributesFrom,
+		if err := mergeDocs(language, org, provider, resourcePrefix, kind, doc.Attributes, docinfo.IncludeAttributesFrom,
 			func(s parsedDoc) map[string]string {
 				return s.Attributes
 			},
@@ -101,7 +101,8 @@ func getDocsForProvider(language language, provider string, resourcePrefix strin
 		}
 
 		// Merge Arguments from source into Attributes of target
-		if err := mergeDocs(language, provider, resourcePrefix, kind, doc.Attributes, docinfo.IncludeAttributesFromArguments,
+		if err := mergeDocs(language, org, provider, resourcePrefix, kind, doc.Attributes,
+			docinfo.IncludeAttributesFromArguments,
 			func(s parsedDoc) map[string]string {
 				return s.Arguments
 			},
@@ -110,7 +111,7 @@ func getDocsForProvider(language language, provider string, resourcePrefix strin
 		}
 
 		// Merge Arguments from source into target
-		if err := mergeDocs(language, provider, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom,
+		if err := mergeDocs(language, org, provider, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom,
 			func(s parsedDoc) map[string]string {
 				return s.Arguments
 			},
@@ -137,11 +138,11 @@ func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte
 }
 
 // mergeDocs adds the docs specified by extractDoc from sourceFrom into the targetDocs
-func mergeDocs(language language, provider string, resourcePrefix string, kind DocKind,
+func mergeDocs(language language, org string, provider string, resourcePrefix string, kind DocKind,
 	targetDocs map[string]string, sourceFrom string, extractDocs func(d parsedDoc) map[string]string) error {
 
 	if sourceFrom != "" {
-		sourceDocs, err := getDocsForProvider(language, provider, resourcePrefix, kind, sourceFrom, nil)
+		sourceDocs, err := getDocsForProvider(language, org, provider, resourcePrefix, kind, sourceFrom, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -534,7 +534,8 @@ func (g *generator) gatherResource(rawname string,
 	// Collect documentation information
 	var parsedDocs parsedDoc
 	if !isProvider {
-		pd, err := getDocsForProvider(g.language, g.info.Name, g.info.GetResourcePrefix(), ResourceDocs, rawname, info.Docs)
+		pd, err := getDocsForProvider(g.language, g.info.GetGitHubOrg(), g.info.Name,
+			g.info.GetResourcePrefix(), ResourceDocs, rawname, info.Docs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -687,8 +688,8 @@ func (g *generator) gatherDataSource(rawname string,
 	name, module := dataSourceName(g.info.Name, rawname, info)
 
 	// Collect documentation information for this data source.
-	parsedDocs, err := getDocsForProvider(g.language, g.info.Name, g.info.GetResourcePrefix(), DataSourceDocs,
-		rawname, info.Docs)
+	parsedDocs, err := getDocsForProvider(g.language, g.info.GetGitHubOrg(), g.info.Name,
+		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info.Docs)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/tfgen/gitinfo.go
+++ b/pkg/tfgen/gitinfo.go
@@ -29,17 +29,16 @@ type GitInfo struct {
 
 const (
 	tfGitHub         = "github.com"
-	tfProvidersOrg   = "terraform-providers"
 	tfProviderPrefix = "terraform-provider"
 )
 
 // getRepoDir gets the source repository for a given provider
-func getRepoDir(prov string) (string, error) {
+func getRepoDir(org, prov string) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-	repo := path.Join(tfGitHub, tfProvidersOrg, tfProviderPrefix+"-"+prov)
+	repo := path.Join(tfGitHub, org, tfProviderPrefix+"-"+prov)
 	pkg, err := build.Import(repo, wd, build.FindOnly)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This doesn't require modifications to other providers which are inside the default `terraform-providers` org.

Fixes #341