### PR TITLE
Eagerly import submodules on module import

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -225,6 +225,7 @@ func (g *pythonGenerator) emitIndex(mod *module, exports, submods []string) erro
 
 	// If there are subpackages, export them in the __all__ variable.
 	if len(submods) > 0 {
+		w.Writefmtln("import importlib")
 		w.Writefmtln("# Make subpackages available:")
 		w.Writefmt("__all__ = [")
 		for i, sub := range submods {
@@ -234,6 +235,9 @@ func (g *pythonGenerator) emitIndex(mod *module, exports, submods []string) erro
 			w.Writefmt("'%s'", pyName(sub))
 		}
 		w.Writefmtln("]")
+		w.Writefmtln("for pkg in __all__:")
+		w.Writefmtln("    if pkg != 'config':")
+		w.Writefmtln("        importlib.import_module(f'{__name__}.{pkg}')")
 	}
 
 	// Now, import anything to export flatly that is a direct export rather than sub-module.


### PR DESCRIPTION
This is a little bit of a strange PR and I'm not entirely sure if it's the right thing to do here, but there are some benefits to be had here that I think are potentially useful.

Unlike many other programming languages, importing a module in Python does not import any of its submodules. This came as a surprise to me. In order to make use of a submodule, you must first import the submodule using the `from` import syntax:

```python
from pulumi_aws import ec2
```

Or explicitly import the module using a relative path:

```python
import pulumi_aws.ec2
```

What does not work is if you import the parent module and then attempt to reference a submodule off of it:

```python
>>> import pulumi_aws as aws
>>> aws.ec2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pulumi_aws' has no attribute 'ec2'
```

It is surprising that this does not work. Unfortunately our (admittedly TypeScript-oriented) programming model heavily encourages users to do this.

That said, Python's import mechanism is ridiculously flexible and we can actually ~hack~ ask Python to eagerly import all submodules on startup if we place this in every package's `__init__.py`:

```python
for pkg in __all__:
    if pkg != 'config': # The "config" package is not importable without an engine
        importlib.import_module(f"{__name__}.{pkg}")
```

Now, we can import the root module and then reference submodules off of it directly:

```python
>>> import pulumi_aws as aws
>>> aws.ec2.Instance
<class 'pulumi_aws.ec2.instance.Instance'>
>>> aws.ec2
<module 'pulumi_aws.ec2' from '/Users/swgillespie/go/src/github.com/pulumi/tf2pulumi/tests/terraform/aws/ec2/venv/lib/python3.6/site-packages/pulumi_aws/ec2/__init__.py'>
```

This is also nice from an IDE perspective, since now an IDE will provide autocompletion for the root package. Seen here, in PyCharm:


![Screen Shot 2019-03-20 at 4 12 24 PM](https://user-images.githubusercontent.com/1871912/54725082-015c1680-4b2b-11e9-8454-983839ea897b.png)

The downsides: this feels like a bit of a hack and I'm not sure if this is idiomatic Python. However, this does make tf2pulumi's job monumentally easier and (in general) makes our Python code look a little bit more like Terraform and TypeScript examples already out there.