### PR TITLE
Mirror inputs onto data source outputs

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -726,12 +726,11 @@ func (g *generator) gatherDataSource(rawname string,
 			}
 		}
 
-		// Also remember computed properties for the resulting return data structure.
-		if args[arg].Computed {
-			// Emit documentation for the property if available
-			fun.rets = append(fun.rets,
-				propertyVariable(arg, sch, cust, parsedDocs.Attributes[arg], "", docURL, true /*out*/))
-		}
+		// Also remember properties for the resulting return data structure.
+		// Emit documentation for the property if available
+		fun.rets = append(fun.rets,
+			propertyVariable(arg, sch, cust, parsedDocs.Attributes[arg],
+				"", docURL, true /*out*/))
 	}
 
 	// If the data source's schema doesn't expose an id property, make one up since we'd like to expose it for data


### PR DESCRIPTION
This fixes a class of usability bugs where using the output from a data source typically also wants the inputs to it.

pulumi/pulumi-azure#120 is a good example of this.

My downstream test into Azure leads me to believe this is the only change required to fix it, though we'll be able to see the generation results from CI here.