### PR TITLE
Prevent requesting unexpected deletes during Update

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -716,6 +716,8 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		// moment.
 		return &pulumirpc.UpdateResponse{Properties: req.GetOlds()}, nil
 	}
+	contract.Assertf(!diff.Destroy && !diff.RequiresNew(),
+		"expected diff to not require deletion or replacement during Update")
 
 	newstate, err := p.tf.Apply(info, state, diff)
 	if newstate == nil {


### PR DESCRIPTION
If the computed diff requires replacement, the contract with the Pulumi provider model has been violated.  We should avoid progressing and doing deletes in this case.

Related to #362.