### PR TITLE
Add support for custom package name for nodejs

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -145,6 +145,7 @@ type OverlayInfo struct {
 
 // JavaScriptInfo contains optional overlay information for Python code-generation.
 type JavaScriptInfo struct {
+	PackageName      string            // Custom name for the NPM package.
 	Dependencies     map[string]string // NPM dependencies to add to package.json.
 	DevDependencies  map[string]string // NPM dev-dependencies to add to package.json.
 	PeerDependencies map[string]string // NPM peer-dependencies to add to package.json.

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -732,9 +732,14 @@ func (g *nodeJSGenerator) emitNPMPackageMetadata(pack *pkg) error {
 	}
 	defer contract.IgnoreClose(w)
 
+	packageName := g.info.JavaScript.PackageName
+	if packageName == "" {
+		packageName = fmt.Sprintf("@pulumi/%s", pack.name)
+	}
+
 	// Create info that will get serialized into an NPM package.json.
 	npminfo := npmPackage{
-		Name:        fmt.Sprintf("@pulumi/%s", pack.name),
+		Name:        packageName,
 		Version:     "${VERSION}",
 		Description: g.info.Description,
 		Keywords:    g.info.Keywords,


### PR DESCRIPTION
I'm not very familiar with the Pulumi's codebase, please, let me know if there's a better approach for this.

Currently, I'm manually changing the package name whenever I build the package, this would allow me to set a custom name to it.