### PR TITLE
Use GetResourcePrefix vs string splitting

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -269,8 +269,7 @@ func (p *Provider) initResourceMaps() {
 
 // camelPascalPulumiName returns the camel and pascal cased name for a given terraform name.
 func (p *Provider) camelPascalPulumiName(name string) (string, string) {
-	// Strip off the module prefix (e.g., "aws_") and then return the camel- and Pascal-cased names.
-	prefix := p.info.Name + "_" // all resources will have this prefix.
+	prefix := p.info.GetResourcePrefix() + "_"
 	contract.Assertf(strings.HasPrefix(name, prefix),
 		"Expected all Terraform resources in this module to have a '%v' prefix", prefix)
 	name = name[len(prefix):]

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -119,3 +119,26 @@ func TestConvertStringToPropertyValue(t *testing.T) {
 		}
 	}
 }
+
+func TestCamelPascalPulumiName(t *testing.T) {
+	p := Provider{
+		info: ProviderInfo{
+			Name:           "name",
+			ResourcePrefix: "resource_prefix",
+		},
+	}
+
+	t.Run("Produces correct names", func(t *testing.T) {
+		camel, pascal := p.camelPascalPulumiName("resource_prefix_some_resource")
+
+		assert.Equal(t, "someResource", camel)
+		assert.Equal(t, "SomeResource", pascal)
+	})
+
+	t.Run("Panics if the prefix is incorrect", func(t *testing.T) {
+		assert.Panics(t, func() {
+			p.camelPascalPulumiName("not_resource_prefix_some_resource")
+		})
+	})
+
+}

--- a/scripts/test-downstream-impact
+++ b/scripts/test-downstream-impact
@@ -15,11 +15,12 @@ REPO_NAME="$1"
 
 git clone "https://github.com/pulumi/${REPO_NAME}.git" "$(go env GOPATH)/src/github.com/pulumi/${REPO_NAME}"
 
-# Run hack-vendor to update Terraform
+# Replace modle for Pulumi Terraform
 cd "$(go env GOPATH)/src/github.com/pulumi/${REPO_NAME}"
 
 git checkout -b "integration/pulumi-terraform/${TRAVIS_JOB_NUMBER}"
-"$(go env GOPATH)"/src/github.com/pulumi/scripts/hack-vendor/hack-vendor github.com/pulumi/pulumi-terraform
+GO111MODULE=on go mod edit -replace=github.com/pulumi/pulumi-terraform=../pulumi-terraform/
+make ensure
 
 # Show the diff in the Gopkg files.
 git diff
@@ -28,7 +29,7 @@ git diff
 git config user.name "Pulumi Bot"
 git config user.email "bot@pulumi.com"
 
-git commit -a -m "Run hack-vendor.sh"
+git commit -a -m "Replace pulumi-terraform module"
 
 # Now, do a build
 make only_build


### PR DESCRIPTION
In 0380ba21, we introduced the concept of a ResourcePrefix which differs from a Terraform Provider's name (to handle Google's Beta provider). We can use the `GetResourcePrefix` method on `ProviderInfo` to obtain this, instead of string splitting where the prefix is required.