### PR TITLE
Pass provider version to engine when invoking or registering resources

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -589,6 +589,15 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	}
 	w.Writefmtln("        }")
 
+	// If the caller didn't request a specific version, supply one using the version of this library.
+	w.Writefmtln("        if (!opts) {")
+	w.Writefmtln("            opts = {}")
+	w.Writefmtln("        }")
+	w.Writefmtln("")
+	w.Writefmtln("        if (!opts.version) {")
+	w.Writefmtln("            opts.version = utilities.getVersion();")
+	w.Writefmtln("        }")
+
 	// Now invoke the super constructor with the type, name, and a property map.
 	w.Writefmtln(`        super("%s", name, inputs, opts);`, res.info.Tok)
 

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -662,6 +662,15 @@ func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 		w.Writefmtln("    args = args || {};")
 	}
 
+	// If the caller didn't request a specific version, supply one using the version of this library.
+	w.Writefmtln("    if (!opts) {")
+	w.Writefmtln("        opts = {}")
+	w.Writefmtln("    }")
+	w.Writefmtln("")
+	w.Writefmtln("    if (!opts.version) {")
+	w.Writefmtln("        opts.version = utilities.getVersion();")
+	w.Writefmtln("    }")
+
 	// Now simply invoke the runtime function with the arguments, returning the results.
 	w.Writefmtln("    return pulumi.runtime.invoke(\"%s\", {", fun.info.Tok)
 	for _, arg := range fun.args {

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -51,6 +51,12 @@ export function requireWithDefault<T>(req: () => T, def: T | undefined): T {
 }
 
 export function getVersion(): string {
-    return require('./package.json').version.slice(1);
+    let version = require('./package.json').version;
+    // Node allows for the version to be prefixed by a "v", while semver doesn't.
+    // If there is a v, strip it off.
+    if (version.indexOf('v') === 0) {
+        version = version.slice(1);
+    }
+    return version;
 }
 `

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -49,4 +49,8 @@ export function requireWithDefault<T>(req: () => T, def: T | undefined): T {
     }
     return def;
 }
+
+export function getVersion(): string {
+    return require('./package.json').version.slice(1);
+}
 `

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -581,6 +581,12 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 		w.Writefmtln("    __args__['%s'] = %s", arg.name, pyName(arg.name))
 	}
 
+	// If the caller explicitly specified a version, use it, otherwise inject this package's version.
+	w.Writefmtln(" .   if opts is None:")
+	w.Writefmtln("         opts = pulumi.ResourceOptions()")
+	w.Writefmtln("     if opts.version is None:")
+	w.Writefmtln("         opts.version = utilities.get_version()")
+
 	// Now simply invoke the runtime function with the arguments.
 	w.Writefmtln("    __ret__ = await pulumi.runtime.invoke('%s', __args__, opts=opts)", fun.info.Tok)
 	w.Writefmtln("")

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -519,6 +519,12 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		w.Writefmtln("")
 	}
 
+	// If the caller explicitly specified a version, use it, otherwise inject this package's version.
+	w.Writefmtln("        if opts is None:")
+	w.Writefmtln("            opts = pulumi.ResourceOptions()")
+	w.Writefmtln("        if opts.version is None:")
+	w.Writefmtln("            opts.version = utilities.get_version()")
+
 	// Finally, chain to the base constructor, which will actually register the resource.
 	w.Writefmtln("        super(%s, __self__).__init__(", res.name)
 	w.Writefmtln("            '%s',", res.info.Tok)

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -2,6 +2,7 @@ package tfgen
 
 const pyUtilitiesFile = `
 import os
+import pkg_resources
 
 def get_env(*args):
     for v in args:
@@ -46,4 +47,13 @@ def require_with_default(req, default):
         if default is not None:
             return default
         raise
+
+def get_version():
+    # __name__ is set to the fully-qualified name of the current module, In our case, it will be
+    # <some module>.utilities. <some module> is the module we want to query the version for.
+    root_package, *rest = __name__.split('.')
+
+    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
+    # for the currently installed version of the root package (i.e. us) and get its version.
+    return pkg_resources.require(root_package)[0].version
 `


### PR DESCRIPTION
Final part of https://github.com/pulumi/pulumi/issues/2389 for TF-based providers.

This PR augments the Python and Node code generators to explicitly pass the current package's version number as an argument to `Invoke`, `ReadResource`, and `RegisterResource`. We managed to accomplish querying our own version without using sed by:

1. For Node, requiring our own `package.json` and inspecting its version and
2. For Python, using `pkg_resources` (AFAIK part of a normal Python installation) to query the version of ourselves that's installed

In either case, if a version wasn't specified by the user, the version of the current package is sent to the engine. I've tested this end-to-end with the Random provider and it works like a charm (along with https://github.com/pulumi/pulumi/pull/2691).