### PR TITLE
Add ability to remove array elements which are empty objects

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -83,16 +83,38 @@ type DataSourceInfo struct {
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {
-	Name        string                 // a name to override the default; "" uses the default.
-	Type        tokens.Type            // a type to override the default; "" uses the default.
-	AltTypes    []tokens.Type          // alternative types that can be used instead of the override.
-	Transform   Transformer            // an optional idemponent transformation, applied before passing to TF.
-	Elem        *SchemaInfo            // a schema override for elements for arrays, maps, and sets.
-	Fields      map[string]*SchemaInfo // a map of custom field names; if a type is missing, the default is used.
-	Asset       *AssetTranslation      // a map of asset translation information, if this is an asset.
-	Default     *DefaultInfo           // an optional default directive to be applied if a value is missing.
-	Stable      *bool                  // to override whether a property is stable or not.
-	MaxItemsOne *bool                  // to override whether this property should project as a scalar or array.
+	// a name to override the default; "" uses the default.
+	Name string
+
+	// a type to override the default; "" uses the default.
+	Type tokens.Type
+
+	// alternative types that can be used instead of the override.
+	AltTypes []tokens.Type
+
+	// an optional idemponent transformation, applied before passing to TF.
+	Transform Transformer
+
+	// a schema override for elements for arrays, maps, and sets.
+	Elem *SchemaInfo
+
+	// a map of custom field names; if a type is missing, the default is used.
+	Fields map[string]*SchemaInfo
+
+	// a map of asset translation information, if this is an asset.
+	Asset *AssetTranslation
+
+	// an optional default directive to be applied if a value is missing.
+	Default *DefaultInfo
+
+	// to override whether a property is stable or not.
+	Stable *bool
+
+	// to override whether this property should project as a scalar or array.
+	MaxItemsOne *bool
+
+	// to remove empty object array elements
+	SuppressEmptyMapElements *bool
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -378,7 +378,14 @@ func MakeTerraformInput(res *PulumiResource, name string,
 			if err != nil {
 				return nil, err
 			}
-			arr = append(arr, e)
+
+			if ps != nil && ps.SuppressEmptyMapElements != nil && *ps.SuppressEmptyMapElements {
+				if eMap, ok := e.(map[string]interface{}); ok && len(eMap) > 0 {
+					arr = append(arr, e)
+				}
+			} else {
+				arr = append(arr, e)
+			}
 		}
 		return arr, nil
 	case v.IsAsset():

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -74,6 +74,9 @@ func TestTerraformInputs(t *testing.T) {
 			"mapWithResourceElem": map[string]interface{}{
 				"someValue": "a value",
 			},
+			"arrayWithNestedOptionalComputedArrays": []interface{}{
+				map[string]interface{}{},
+			},
 		}),
 		map[string]*schema.Schema{
 			// Type mapPropertyValue as a map so that keys aren't mangled in the usual way.
@@ -130,6 +133,29 @@ func TestTerraformInputs(t *testing.T) {
 					},
 				},
 			},
+			"array_with_nested_optional_computed_arrays": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_value": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"nested_inner_value": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		map[string]*SchemaInfo{
 			// Reverse map string_property_value to the stringo property.
@@ -140,6 +166,9 @@ func TestTerraformInputs(t *testing.T) {
 				Name:        "optionalConfigOther",
 				MaxItemsOne: boolPointer(true),
 			},
+			"array_with_nested_optional_computed_arrays": {
+				SuppressEmptyMapElements: boolPointer(true),
+			},
 		},
 		nil,   /* assets */
 		nil,   /* config */
@@ -147,6 +176,8 @@ func TestTerraformInputs(t *testing.T) {
 		false, /*useRawNames*/
 	)
 	assert.Nil(t, err)
+
+	var nilInterfaceSlice []interface{}
 	assert.Equal(t, map[string]interface{}{
 		"bool_property_value":   false,
 		"number_property_value": 42,
@@ -194,6 +225,7 @@ func TestTerraformInputs(t *testing.T) {
 				"some_value": "a value",
 			},
 		},
+		"array_with_nested_optional_computed_arrays": nilInterfaceSlice,
 	}, result)
 
 	_, err = MakeTerraformInputs(


### PR DESCRIPTION
This PR is potential way to fix the issue described in pulumi/pulumi-azure#2511, and several other variants of it we have seen in the past. It's unclear that removing empty array elements is always the right option, so we make it opt-in for resources where it is known to be effective instead of applying it generally.