### PR TITLE
Don't emit `config.require` calls

### DIFF
--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -244,12 +244,7 @@ func (g *goGenerator) emitConfigVariables(mod *module) error {
 }
 
 func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
-	var getfunc string
-	if v.optional() {
-		getfunc = "Get"
-	} else {
-		getfunc = "Require"
-	}
+	getfunc := "Get"
 
 	var gettype string
 	var functype string
@@ -281,9 +276,6 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 		w.Writefmtln("\tif dv, ok := %s.(%s); ok {", defaultValue, gettype)
 		w.Writefmtln("\t\treturn dv")
 		w.Writefmtln("\t}")
-		if !v.optional() {
-			w.Writefmtln("\tpanic(err.Error())")
-		}
 		w.Writefmtln("\treturn v")
 	} else {
 		w.Writefmtln("\treturn config.%s%s(ctx, \"%s:%s\")", getfunc, functype, g.pkg, v.name)

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -342,15 +342,10 @@ func (g *nodeJSGenerator) emitConfigVariables(mod *module) (string, error) {
 }
 
 func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
-	var getfunc string
-	if v.optional() {
-		getfunc = "get"
-	} else {
-		getfunc = "require"
-	}
+	getfunc := "get"
 	if v.schema.Type != schema.TypeString {
 		// Only try to parse a JSON object if the config isn't a straight string.
-		getfunc = fmt.Sprintf("%sObject<%s>", getfunc, tsType(v, false /*noflags*/, !v.out /*wrapInput*/))
+		getfunc = fmt.Sprintf("getObject<%s>", tsType(v, false /*noflags*/, !v.out /*wrapInput*/))
 	}
 	var anycast string
 	if v.info != nil && v.info.Type != "" {
@@ -365,11 +360,7 @@ func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 
 	configFetch := fmt.Sprintf("__config.%s(\"%s\")", getfunc, v.name)
 	if defaultValue := tsDefaultValue(v); defaultValue != "undefined" {
-		if v.optional() {
-			configFetch += " || " + defaultValue
-		} else {
-			configFetch = fmt.Sprintf("utilities.requireWithDefault(() => %s, %s)", configFetch, defaultValue)
-		}
+		configFetch += " || " + defaultValue
 	}
 
 	w.Writefmtln("export let %s: %s = %s%s;", v.name, tsType(v, true /*noflags*/, !v.out /*wrapInput*/), anycast,

--- a/pkg/tfgen/generate_nodejs_utilities.go
+++ b/pkg/tfgen/generate_nodejs_utilities.go
@@ -1,8 +1,6 @@
 package tfgen
 
 const tsUtilitiesFile = `
-import * as pulumi from "@pulumi/pulumi";
-
 export function getEnv(...vars: string[]): string | undefined {
     for (const v of vars) {
         const value = process.env[v];
@@ -37,17 +35,6 @@ export function getEnvNumber(...vars: string[]): number | undefined {
         }
     }
     return undefined;
-}
-
-export function requireWithDefault<T>(req: () => T, def: T | undefined): T {
-    try {
-        return req();
-    } catch (err) {
-        if (def === undefined) {
-            throw err;
-        }
-    }
-    return def;
 }
 
 export function getVersion(): string {

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -317,20 +317,9 @@ func (g *pythonGenerator) emitConfigVariables(mod *module) (string, error) {
 }
 
 func (g *pythonGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
-	var getfunc string
-	if v.optional() {
-		getfunc = "get"
-	} else {
-		getfunc = "require"
-	}
-
-	configFetch := fmt.Sprintf("__config__.%s('%s')", getfunc, v.name)
+	configFetch := fmt.Sprintf("__config__.get('%s')", v.name)
 	if defaultValue := pyDefaultValue(v); defaultValue != "" {
-		if v.optional() {
-			configFetch += " or " + defaultValue
-		} else {
-			configFetch = fmt.Sprintf("utilities.require_with_default(lambda: %s, %s)", configFetch, defaultValue)
-		}
+		configFetch += " or " + defaultValue
 	}
 
 	w.Writefmtln("%s = %s", pyName(v.name), configFetch)

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -40,14 +40,6 @@ def get_env_float(*args):
             return None
     return None
 
-def require_with_default(req, default):
-    try:
-        return req()
-    except:
-        if default is not None:
-            return default
-        raise
-
 def get_version():
     # __name__ is set to the fully-qualified name of the current module, In our case, it will be
     # <some module>.utilities. <some module> is the module we want to query the version for.


### PR DESCRIPTION
We read `config` to populate variables with the values of configuration.  This is useful, but not all usage of the provider depends on Pulumi configuration, as explicit providers (1st class providers) do not configure themselves with Pulumi config.
    
While we still want to populate the `config` module for a provider with the Pulumi configuration, we do not want to fail when it is missing - we just want to leave the variables undefined.  Therefore, we should not emit `require` calls.
    
Helpful error messages are still provided to the user, but they are provided through a more centralized contract with the provider Configure RPC instead of via ad-hoc `require` calls in the SDKs.
    
Fixes pulumi/pulumi#2725
