### PR TITLE
Correctly type config module exports

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -363,8 +363,8 @@ func (g *nodeJSGenerator) emitConfigVariable(w *tools.GenWriter, v *variable) {
 		configFetch += " || " + defaultValue
 	}
 
-	w.Writefmtln("export let %s: %s = %s%s;", v.name, tsType(v, true /*noflags*/, !v.out /*wrapInput*/), anycast,
-		configFetch)
+	w.Writefmtln("export let %s: %s | undefined = %s%s;", v.name, tsType(v, false /*noflags*/, !v.out /*wrapInput*/),
+		anycast, configFetch)
 }
 
 // sanitizeForDocComment ensures that no `*/` sequence appears in the string, to avoid


### PR DESCRIPTION
Fixes a flaw in #375 that leads to TypeScript type errors in generated `vars.ts`.

Note that adopting this into a provider is a TypeScript-level breaking change, as code that reads (e.g.) `aws.config.region` will now need to handle the case that it is undefined.  This is a simple break to workaround, and only an issue at the TypeScript level, so not expecting to need to do major version bump on this.