### PR TITLE
Bridge between PEP440 and semver versions

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -695,7 +695,10 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	}
 
 	// Sort the entries so they are deterministic.
-	var reqnames []string
+	reqnames := []string{
+		"semver>=2.8.1",
+		"parver>=0.2.1",
+	}
 	for req := range reqs {
 		reqnames = append(reqnames, req)
 	}

--- a/pkg/tfgen/generate_python_utilities.go
+++ b/pkg/tfgen/generate_python_utilities.go
@@ -4,6 +4,9 @@ const pyUtilitiesFile = `
 import os
 import pkg_resources
 
+from semver import VersionInfo as SemverVersion
+from parver import Version as PEP440Version
+
 def get_env(*args):
     for v in args:
         value = os.getenv(v)
@@ -47,5 +50,22 @@ def get_version():
 
     # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
     # for the currently installed version of the root package (i.e. us) and get its version.
-    return pkg_resources.require(root_package)[0].version
+
+    # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
+    # to receive a valid semver string when receiving requests from the language host, so it's our
+    # responsibility as the library to convert our own PEP440 version into a valid semver string.
+
+    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version = PEP440Version.parse(pep440_version_string)
+    (major, minor, patch) = pep440_version.release
+    prerelease = None
+    if pep440_version.dev is not None:
+        prerelease = f"dev.{pep440_version.dev}"
+
+    # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support
+    # for dev builds, while semver encodes them as "prerelease" versions. In order to bridge between the two, we convert
+    # our dev build version into a prerelease tag. This matches what all of our other packages do when constructing
+    # their own semver string.
+    semver_version = SemverVersion(major=major, minor=minor, patch=patch, prerelease=prerelease)
+    return str(semver_version)
 `


### PR DESCRIPTION
Python PEP440 is slightly different in incompatible ways from semver, so
sending our own PEP440 version to the engine that is expecting a semver
string caused problems when using prerelease builds.

To fix this, this commit makes sure that versions are explicitly coerced
into semver before handing them to the core Pulumi SDK. The engine
always expects semver strings, so converting to semver as early as
possible prevents odd incompatibilities that arise when PEP440 versions
are sent to the engine.