### PR TITLE
Do not flow version information with the request

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -580,14 +580,15 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	}
 	w.Writefmtln("        }")
 
+	// TODO[pulumi/pulumi#2753]: We should re-enable this code once we have a solution for #2753.
 	// If the caller didn't request a specific version, supply one using the version of this library.
-	w.Writefmtln("        if (!opts) {")
-	w.Writefmtln("            opts = {}")
-	w.Writefmtln("        }")
-	w.Writefmtln("")
-	w.Writefmtln("        if (!opts.version) {")
-	w.Writefmtln("            opts.version = utilities.getVersion();")
-	w.Writefmtln("        }")
+	// w.Writefmtln("        if (!opts) {")
+	// w.Writefmtln("            opts = {}")
+	// w.Writefmtln("        }")
+	// w.Writefmtln("")
+	// w.Writefmtln("        if (!opts.version) {")
+	// w.Writefmtln("            opts.version = utilities.getVersion();")
+	// w.Writefmtln("        }")
 
 	// Now invoke the super constructor with the type, name, and a property map.
 	w.Writefmtln(`        super("%s", name, inputs, opts);`, res.info.Tok)
@@ -653,14 +654,15 @@ func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 		w.Writefmtln("    args = args || {};")
 	}
 
+	// TODO[pulumi/pulumi#2753]: We should re-enable this code once we have a solution for #2753.
 	// If the caller didn't request a specific version, supply one using the version of this library.
-	w.Writefmtln("    if (!opts) {")
-	w.Writefmtln("        opts = {}")
-	w.Writefmtln("    }")
-	w.Writefmtln("")
-	w.Writefmtln("    if (!opts.version) {")
-	w.Writefmtln("        opts.version = utilities.getVersion();")
-	w.Writefmtln("    }")
+	// w.Writefmtln("    if (!opts) {")
+	// w.Writefmtln("        opts = {}")
+	// w.Writefmtln("    }")
+	// w.Writefmtln("")
+	// w.Writefmtln("    if (!opts.version) {")
+	// w.Writefmtln("        opts.version = utilities.getVersion();")
+	// w.Writefmtln("    }")
 
 	// Now simply invoke the runtime function with the arguments, returning the results.
 	w.Writefmtln("    return pulumi.runtime.invoke(\"%s\", {", fun.info.Tok)

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -508,11 +508,12 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		w.Writefmtln("")
 	}
 
+	// TODO[pulumi/pulumi#2753]: We should re-enable this code once we have a solution for #2753.
 	// If the caller explicitly specified a version, use it, otherwise inject this package's version.
-	w.Writefmtln("        if opts is None:")
-	w.Writefmtln("            opts = pulumi.ResourceOptions()")
-	w.Writefmtln("        if opts.version is None:")
-	w.Writefmtln("            opts.version = utilities.get_version()")
+	// w.Writefmtln("        if opts is None:")
+	// w.Writefmtln("            opts = pulumi.ResourceOptions()")
+	// w.Writefmtln("        if opts.version is None:")
+	// w.Writefmtln("            opts.version = utilities.get_version()")
 
 	// Finally, chain to the base constructor, which will actually register the resource.
 	w.Writefmtln("        super(%s, __self__).__init__(", res.name)
@@ -570,11 +571,12 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 		w.Writefmtln("    __args__['%s'] = %s", arg.name, pyName(arg.name))
 	}
 
-	// If the caller explicitly specified a version, use it, otherwise inject this package's version.
-	w.Writefmtln("    if opts is None:")
-	w.Writefmtln("        opts = pulumi.ResourceOptions()")
-	w.Writefmtln("    if opts.version is None:")
-	w.Writefmtln("        opts.version = utilities.get_version()")
+	// TODO[pulumi/pulumi#2753]: We should re-enable this code once we have a solution for #2753.
+	// // If the caller explicitly specified a version, use it, otherwise inject this package's version.
+	// w.Writefmtln("    if opts is None:")
+	// w.Writefmtln("        opts = pulumi.ResourceOptions()")
+	// w.Writefmtln("    if opts.version is None:")
+	// w.Writefmtln("        opts.version = utilities.get_version()")
 
 	// Now simply invoke the runtime function with the arguments.
 	w.Writefmtln("    __ret__ = await pulumi.runtime.invoke('%s', __args__, opts=opts)", fun.info.Tok)


### PR DESCRIPTION
In absence of a fix for pulumi/pulumi#2753, passing a version here
means that every time you upgrade your package, all the resources it
managed will be replaced.

That's not an experience we want, so for now we are backing out this
part of the change.