### PR TITLE
Force UTF-8 when opening README.rst

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -646,7 +646,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	// Generate a readme method which will load README.rst, we use this to fill out the
 	// long_description field in the setup call.
 	w.Writefmtln("def readme():")
-	w.Writefmtln("    with open('README.rst') as f:")
+	w.Writefmtln("    with open('README.rst', encoding='utf-8') as f:")
 	w.Writefmtln("        return f.read()")
 	w.Writefmtln("")
 


### PR DESCRIPTION
I believe that this will address issues like: https://github.com/pulumi/pulumi-aws/issues/587.

I'm going to try to confirm this actually fixes the issue on my windows machine, assuming I can get it to believe it is in the problematic locale and can reproduce the issue.