### PR TITLE
Fix pulumi/pulumi#2829

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG details important changes made in each version of the
 
 ## v0.18.3 (Unreleased)
 
+- Fixed a bug that caused unnecessary changes if the first operation after upgrading a bridged provider was a `pulumi refresh`.
+
 ### Improvements
 
 - Automatically generate `isInstance` type guards for implementations of `Resource`.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -650,7 +650,8 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	}
 
 	// If we are in a "get" rather than a "refresh", we should call the Terraform importer, if one is defined.
-	if len(req.GetProperties().GetFields()) == 0 {
+	isRefresh := len(req.GetProperties().GetFields()) != 0
+	if !isRefresh {
 		attrs, err = res.runTerraformImporter(id, p)
 		if err != nil {
 			// Pass through any error running the importer
@@ -679,7 +680,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			return nil, err
 		}
 
-		inputs, err := extractInputsFromOutputs(oldInputs, props, res.TF.Schema, res.Schema.Fields)
+		inputs, err := extractInputsFromOutputs(oldInputs, props, res.TF.Schema, res.Schema.Fields, isRefresh)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
These changes fix pulumi/pulumi#2829. This bug occurred with the
following sequence of events:

- A user creates a stack with resources from a version of a TF-based
  provider that predates support for the `__defaults` annotation
- The user updates the provider to a version that does support the
  `__defaults` annotation
- The user runs a refresh without any intervening update

In this scenario, the refresh will add empty `__defaults` annotations to
every property map in the refreshed inputs. This will then prevent any
defaults that were populated when any resource was created from being
picked up by the provider. Becuase `name` properties are often populated
using defaults and are often `ForceNew`, this will cause large numbers
of unnecessary replaces.

These changes fix this problem by only adding `__defaults` annotations
where none were present during a `Read` if the `Read` is not for a
refresh.

Users that have already ended up in the scenario described above can
repair their stack by deleting all `__defaults` annotations and running
at least one no-op update as described in pulumi/pulumi#2829.