### PR TITLE
Allow JSON arrays in TransformJSONDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG details important changes made in each version of the
 ### Improvements
 
 - Automatically generate `isInstance` type guards for implementations of `Resource`.
+- `TransformJSONDocument` now accepts arrays (in addition to maps).
 
 ## v0.18.2 (Released May 28th, 2019)
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -828,9 +828,14 @@ func TestCustomTransforms(t *testing.T) {
 		nil, "v", resource.PropertyValue{}, resource.NewObjectProperty(resource.NewPropertyMapFromMap(doc)),
 		tfs, psi, nil, nil, false, false)
 	assert.NoError(t, err)
-	if !assert.Equal(t, `{"a":99,"b":false}`, v1) {
-		assert.Equal(t, `{"b":false,"a":99}`, v1)
-	}
+	assert.Equal(t, `{"a":99,"b":false}`, v1)
+
+	array := []resource.PropertyValue{resource.NewObjectProperty(resource.NewPropertyMapFromMap(doc))}
+	v1Array, err := MakeTerraformInput(
+		nil, "v", resource.PropertyValue{}, resource.NewArrayProperty(array),
+		tfs, psi, nil, nil, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"a":99,"b":false}]`, v1Array)
 
 	v2, err := MakeTerraformInput(
 		nil, "v", resource.PropertyValue{}, resource.NewStringProperty(`{"a":99,"b":false}`),

--- a/pkg/tfbridge/transforms.go
+++ b/pkg/tfbridge/transforms.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TransformJSONDocument permits either a string, which is presumed to represent an already-stringified JSON document,
-// or a map, which will be transformed into its JSON representation.
+// or a map/array, which will be transformed into its JSON representation.
 func TransformJSONDocument(v resource.PropertyValue) (resource.PropertyValue, error) {
 	// We can't marshal properties that contain unknowns. Turn these into an unknown value instead.
 	if v.ContainsUnknowns() {
@@ -31,7 +31,7 @@ func TransformJSONDocument(v resource.PropertyValue) (resource.PropertyValue, er
 
 	if v.IsString() {
 		return v, nil
-	} else if v.IsObject() {
+	} else if v.IsObject() || v.IsArray() {
 		m := v.Mappable()
 		b, err := json.Marshal(m)
 		if err != nil {

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -952,11 +952,15 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 					return err
 				}
 
+				// We allow types to have a `[]` suffix to indicate an array.
+				// Thus, strip the `[]` suffix for the import so just the type itself is imported.
+				importName := strings.TrimSuffix(string(ct.Name()), "[]")
+
 				// Now just mark the member in the resulting map.
 				if imports[relmod] == nil {
 					imports[relmod] = make(map[string]bool)
 				}
-				imports[relmod][string(ct.Name())] = true
+				imports[relmod][importName] = true
 			}
 		}
 

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -105,6 +105,24 @@ var tsTypeTests = []typeTest{
 		expectedOutput: "string",
 		expectedInput:  "pulumi.Input<string | Foo>",
 	},
+	{
+		// Basic array alt types
+		info: &tfbridge.SchemaInfo{
+			Type:     "string",
+			AltTypes: []tokens.Type{"Foo[]"},
+		},
+		expectedOutput: "string",
+		expectedInput:  "pulumi.Input<string | Foo[]>",
+	},
+	{
+		// Complex array alt types
+		info: &tfbridge.SchemaInfo{
+			Type:     "string",
+			AltTypes: []tokens.Type{"pkg:mod/foo:Foo[]"},
+		},
+		expectedOutput: "string",
+		expectedInput:  "pulumi.Input<string | Foo[]>",
+	},
 }
 
 func Test_TsTypes(t *testing.T) {
@@ -144,4 +162,24 @@ func Test_Issue130(t *testing.T) {
 		schema: schema,
 		out:    false,
 	}, false, true))
+}
+
+func Test_GatherCustomImports_ComplexArrayAltType(t *testing.T) {
+	expected := importMap{
+		"./foo": map[string]bool{
+			"Foo": true,
+		},
+	}
+
+	g := &nodeJSGenerator{pkg: "pkg"}
+	info := tfbridge.SchemaInfo{
+		Type:     "string",
+		AltTypes: []tokens.Type{"pkg:mod/foo:Foo[]"},
+	}
+	actual := make(importMap)
+
+	err := g.gatherCustomImports(newModule("mod"), &info, actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
There are certain properties that accept a JSON array, such as an S3 bucket's website routing_rules in the AWS provider (see https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#routing_rules). This change modifies the `TransformJSONDocument` to accept arrays in addition to maps, which will allow us to offer stronger typing for such properties.

This seemed like a practical and reasonable change to me, and I couldn't really think of any downsides, but let me know if there are reasons why we wouldn't want to do this.