### PR TITLE
Use a schematized reader in MakeTerraformResult.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG details important changes made in each version of the
 ## v0.18.3 (Unreleased)
 
 - Fixed a bug that caused unnecessary changes if the first operation after upgrading a bridged provider was a `pulumi refresh`.
+- Fixed a bug that caused maps with keys containing a '.' character to be incorrectly treated as containing nested maps when deserializing Terraform attributes.
 
 ### Improvements
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -480,6 +480,9 @@ func MakeTerraformResult(state *terraform.InstanceState,
 				outs[key] = res.Value
 			}
 		}
+		if _, ok := outs["id"]; !ok {
+			outs["id"] = attrs["id"]
+		}
 	}
 	outMap := MakeTerraformOutputs(outs, tfs, ps, nil, false)
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -480,6 +480,9 @@ func MakeTerraformResult(state *terraform.InstanceState,
 				outs[key] = res.Value
 			}
 		}
+
+		// Populate the "id" property if it is not set. Most schemas do not include this property, and leaving it out
+		// can cause unnecessary diffs when refreshing/updating resources after a provider upgrade.
 		if _, ok := outs["id"]; !ok {
 			outs["id"] = attrs["id"]
 		}

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -67,6 +67,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "object_property_value", map[string]interface{}{
 					"property_a": "a",
 					"property_b": "true",
+					"property.c": "some.value",
 				})
 				mustSet(data, "nested_resources", []interface{}{
 					map[string]interface{}{
@@ -88,6 +89,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "object_property_value", map[string]interface{}{
 					"property_a": "a",
 					"property_b": "true",
+					"property.c": "some.value",
 				})
 				mustSet(data, "nested_resources", []interface{}{
 					map[string]interface{}{
@@ -109,6 +111,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "object_property_value", map[string]interface{}{
 					"property_a": "a",
 					"property_b": "true",
+					"property.c": "some.value",
 				})
 				mustSet(data, "nested_resources", []interface{}{
 					map[string]interface{}{
@@ -171,6 +174,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "object_property_value", map[string]interface{}{
 					"property_a": "a",
 					"property_b": "true",
+					"property.c": "some.value",
 				})
 				mustSet(data, "nested_resources", []interface{}{
 					map[string]interface{}{

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1125,7 +1125,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err := plugin.UnmarshalProperties(resp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
-		"id":      "MyID",
 		"inputA":  "input_a_read",
 		"inoutC":  "inout_c_read",
 		"inoutD":  "inout_d_read",
@@ -1184,7 +1183,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err = plugin.UnmarshalProperties(createResp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
-		"id":     "MyID",
 		"inputA": "input_a_create",
 		"inoutC": "inout_c_create",
 		"inoutD": "inout_d_default",
@@ -1212,7 +1210,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err = plugin.UnmarshalProperties(resp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
-		"id":     "MyID",
 		"inputA": "input_a_create",
 		"inoutC": "inout_c_create",
 		"inoutD": "inout_d_read",

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -541,7 +542,8 @@ func TestMetaProperties(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, read)
 
-	props := MakeTerraformResult(read, res.Schema, nil)
+	props, err := MakeTerraformResult(read, res.Schema, nil)
+	assert.NoError(t, err)
 	assert.NotNil(t, props)
 
 	attrs, meta, err := MakeTerraformAttributes(res, props, res.Schema, nil, nil, false)
@@ -569,7 +571,8 @@ func TestMetaProperties(t *testing.T) {
 
 	// Remove the resource's meta-attributes and ensure that we do not include them in the result.
 	read2.Meta = map[string]interface{}{}
-	props = MakeTerraformResult(read2, res.Schema, nil)
+	props, err = MakeTerraformResult(read2, res.Schema, nil)
+	assert.NoError(t, err)
 	assert.NotNil(t, props)
 	assert.NotContains(t, props, metaKey)
 
@@ -582,7 +585,8 @@ func TestMetaProperties(t *testing.T) {
 	create, err := testTFProvider.Apply(info, state, diff)
 	assert.NoError(t, err)
 
-	props = MakeTerraformResult(create, res.Schema, nil)
+	props, err = MakeTerraformResult(create, res.Schema, nil)
+	assert.NoError(t, err)
 	assert.NotNil(t, props)
 
 	attrs, meta, err = MakeTerraformAttributes(res, props, res.Schema, nil, nil, false)
@@ -591,6 +595,41 @@ func TestMetaProperties(t *testing.T) {
 	assert.NotNil(t, meta)
 
 	assert.Contains(t, meta, schema.TimeoutKey)
+}
+
+// Test that MakeTerraformResult reads property values appropriately.
+func TestResultAttributesRoundTrip(t *testing.T) {
+	const resName = "example_resource"
+	res := testTFProvider.ResourcesMap["example_resource"]
+
+	info := &terraform.InstanceInfo{Type: resName}
+	state := &terraform.InstanceState{ID: "0", Attributes: map[string]string{}, Meta: map[string]interface{}{}}
+
+	read, err := testTFProvider.Refresh(info, state)
+	assert.NoError(t, err)
+	assert.NotNil(t, read)
+
+	props, err := MakeTerraformResult(read, res.Schema, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, props)
+
+	attrs, _, err := MakeTerraformAttributes(res, props, res.Schema, nil, nil, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, attrs)
+
+	// We do not fill in the "id" field. Remove it before diffing.
+	delete(state.Attributes, "id")
+
+	// We may add extra "%" fields to represent map counts. These diffs are innocuous. If we only see them in the
+	// attributes produced by MakeTerraformResult, ignore them.
+	for k, v := range attrs {
+		expected, ok := read.Attributes[k]
+		if !ok {
+			assert.True(t, strings.HasSuffix(k, ".%"))
+		} else {
+			assert.Equal(t, expected, v)
+		}
+	}
 }
 
 // Test that an unset list still generates a length attribute.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -617,9 +617,6 @@ func TestResultAttributesRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, attrs)
 
-	// We do not fill in the "id" field. Remove it before diffing.
-	delete(state.Attributes, "id")
-
 	// We may add extra "%" fields to represent map counts. These diffs are innocuous. If we only see them in the
 	// attributes produced by MakeTerraformResult, ignore them.
 	for k, v := range attrs {
@@ -1125,6 +1122,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err := plugin.UnmarshalProperties(resp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"id":      "MyID",
 		"inputA":  "input_a_read",
 		"inoutC":  "inout_c_read",
 		"inoutD":  "inout_d_read",
@@ -1183,6 +1181,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err = plugin.UnmarshalProperties(createResp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"id":     "MyID",
 		"inputA": "input_a_create",
 		"inoutC": "inout_c_create",
 		"inoutD": "inout_d_default",
@@ -1210,6 +1209,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	outs, err = plugin.UnmarshalProperties(resp.GetProperties(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"id":     "MyID",
 		"inputA": "input_a_create",
 		"inoutC": "inout_c_create",
 		"inoutD": "inout_d_read",


### PR DESCRIPTION
This prevents bugs where `flatmap.Expand` would misinterpret the
contents of a resource's state with respect to the shape described by
the resource's schema. The most critical misinterpretation involves
submaps with keys that contain "." characters: in this case, the key is
misinterpreted as describing another submap rather than a string ->
string entry. For example, given the following TF state:

```
"attributes": {
    "tags.%": "1",
    "tags.pulumi.io/foo/bar": "baz",
},
```

flatmap will expand this to:
```
{
    "tags": {
        "pulumi": {
            "io/foo/bar": "baz"
        }
    }
```

instead of the expected
```
    "tags": {
        "pulumi.io/foo/bar": "baz"
    }
```

Fixes #394.