### PR TITLE
Fix detailed diffs with nested computed values.

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -575,6 +575,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		DeleteBeforeReplace: len(replaces) > 0 && res.Schema.DeleteBeforeReplace,
 		Diffs:               properties,
 		DetailedDiff:        makeDetailedDiff(res.TF.Schema, res.Schema.Fields, olds, news, diff),
+		HasDetailedDiff:     true,
 	}, nil
 }
 


### PR DESCRIPTION
The Terraform diff logic is a bit strange for composite values that
contain computed values (e.g. lists, sets, and maps where any element is
computed): in these cases, the diff will indicate a change in the
element count where the new value is computed, and will indicate that
certain elements have been deleted from the old value. We will currently
convert these diffs in a way that isn't particularly helpful (and
indeed, we will panic on sets with any computed element): we will
faithfully reflect the deletes rather than indicating that the nested
elements have changed.

These changes update our diff logic to report a change to the entire
composite value if the Terraform diff contains the characteristic change
to the value's count s.t. the count is computed. It is the
responsibility of the consumer of the detailed diff to render the
difference between the old and new value.

These changes also properly set the `HasDetailedDiff` property in the
result of `Diff` s.t. the Pulumi engine uses the detailed diff for
rendering.

Fixes #402.