### PR TITLE
Improve TF docs generation

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -587,12 +587,14 @@ func cleanupDoc(doc parsedDoc) parsedDoc {
 
 var markdownLink = regexp.MustCompile(`\[([^\]]*)\]\(([^\)]*)\)`)
 
+const elidedDocComment = "<elided>"
+
 // cleanupText processes markdown strings from TF docs and cleans them for inclusion in Pulumi docs
 func cleanupText(text string) string {
 	// Remove incorrect documentation that should have been cleaned up in our forks.
 	// TODO: fail the build in the face of such text, once we have a processes in place.
 	if strings.Contains(text, "Terraform") || strings.Contains(text, "terraform") {
-		return ""
+		return elidedDocComment
 	}
 
 	// Replace occurrences of "->" or "~>" with just ">", to get a proper MarkDown note.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -303,7 +303,7 @@ func (g *goGenerator) emitConfigAccessor(w *tools.GenWriter, v *variable) {
 		gettype, functype = "string", ""
 	}
 
-	if v.doc != "" {
+	if v.doc != "" && v.doc != elidedDocComment {
 		g.emitDocComment(w, v.doc, v.docURL, "")
 	} else if v.rawdoc != "" {
 		g.emitRawDocComment(w, v.rawdoc, "")
@@ -343,7 +343,11 @@ func (g *goGenerator) emitUtilities(mod *module) error {
 }
 
 func (g *goGenerator) emitDocComment(w *tools.GenWriter, comment, docURL, prefix string) {
-	if comment != "" {
+	if comment == elidedDocComment && docURL == "" {
+		return
+	}
+
+	if comment != elidedDocComment {
 		lines := strings.Split(comment, "\n")
 		for i, docLine := range lines {
 			// Break if we get to the last line and it's empty
@@ -353,10 +357,14 @@ func (g *goGenerator) emitDocComment(w *tools.GenWriter, comment, docURL, prefix
 			// Print the line of documentation
 			w.Writefmtln("%s// %s", prefix, docLine)
 		}
+
 		if docURL != "" {
 			w.Writefmtln("%s//", prefix)
-			w.Writefmtln("%s// > This content is derived from %s.", prefix, docURL)
 		}
+	}
+
+	if docURL != "" {
+		w.Writefmtln("%s// > This content is derived from %s.", prefix, docURL)
 	}
 }
 
@@ -388,7 +396,7 @@ func (g *goGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType) {
 	}
 	w.Writefmtln("type %s struct {", pot.name)
 	for _, prop := range pot.props {
-		if prop.doc != "" {
+		if prop.doc != "" && prop.doc != elidedDocComment {
 			g.emitDocComment(w, prop.doc, prop.docURL, "\t")
 		} else if prop.rawdoc != "" {
 			g.emitRawDocComment(w, prop.rawdoc, "\t")
@@ -517,7 +525,7 @@ func (g *goGenerator) emitResourceType(mod *module, res *resourceType) error {
 	w.Writefmtln("}")
 	w.Writefmtln("")
 	for _, prop := range res.outprops {
-		if prop.doc != "" {
+		if prop.doc != "" && prop.doc != elidedDocComment {
 			g.emitDocComment(w, prop.doc, prop.docURL, "")
 		} else if prop.rawdoc != "" {
 			g.emitRawDocComment(w, prop.rawdoc, "")

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -202,7 +202,7 @@ func (g *goGenerator) emitModule(mod *module) error {
 // ensurePackageComment writes out a file with a module-wide comment, provided one doesn't already exist.
 func (g *goGenerator) ensurePackageComment(mod *module, dir string) error {
 	pkg := g.goPackageName(mod)
-	rf := filepath.Join(dir, pkg+".go")
+	rf := filepath.Join(dir, "_about.go")
 	_, err := os.Stat(rf)
 	if err == nil {
 		return nil // file already exists, exit right away.


### PR DESCRIPTION
- Don't drop URLs to documentation when the content has been elided.
- Don't write a source file named after the package itself, this is likely to conflict with resources in the package.