### PR TITLE
Expanded error message about a missing field value with a config default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG details important changes made in each version of the
 
 - Terraform-based providers can now communicate detailed information about the difference between a resource's desired and actual state during a Pulumi update.
 - Add the ability to inject CustomTimeouts into the InstanceDiff during a pulumi update.
-- Better error message for missing required fields with default config (#400).
+- Better error message for missing required fields with default config ([#400](https://github.com/pulumi/pulumi-terraform/issues/400)).
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG details important changes made in each version of the
 
 - Terraform-based providers can now communicate detailed information about the difference between a resource's desired and actual state during a Pulumi update.
 - Add the ability to inject CustomTimeouts into the InstanceDiff during a pulumi update.
+- Better error message for missing required fields with default config (#400).
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -420,13 +420,15 @@ func (p *Provider) Configure(ctx context.Context,
 var requiredFieldRegex = regexp.MustCompile("\"(.*?)\": required field is not set")
 
 func (p *Provider) formatFailureReason(res Resource, reason string) string {
-	// If a required field is missing and the value can be set via config, extend the error with a hint to set the proper config value
+	// If a required field is missing and the value can be set via config,
+	// extend the error with a hint to set the proper config value
 	name := requiredFieldRegex.FindStringSubmatch(reason)
 	if len(name) == 2 {
 		field := res.Schema.Fields[name[1]]
 		if field != nil && field.Default != nil {
 			if configKey := field.Default.Config; configKey != "" {
-				return fmt.Sprintf("%s. Either set it explicitly or configure it with 'pulumi config set %s:%s <value>'.", reason, p.module, configKey)
+				hint := "%s. Either set it explicitly or configure it with 'pulumi config set %s:%s <value>'."
+				return fmt.Sprintf(hint, reason, p.module, configKey)
 			}
 		}
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -417,6 +417,8 @@ func (p *Provider) Configure(ctx context.Context,
 	return &pulumirpc.ConfigureResponse{}, nil
 }
 
+// Parse the TF error of a missing field:
+// https://github.com/hashicorp/terraform/blob/7f5ffbfe9027c34c4ce1062a42b6e8d80b5504e0/helper/schema/schema.go#L1356
 var requiredFieldRegex = regexp.MustCompile("\"(.*?)\": required field is not set")
 
 func (p *Provider) formatFailureReason(res Resource, reason string) string {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -420,7 +420,7 @@ func (p *Provider) Configure(ctx context.Context,
 var requiredFieldRegex = regexp.MustCompile("\"(.*?)\": required field is not set")
 
 func (p *Provider) formatFailureReason(res Resource, reason string) string {
-	// If required field is missing and the value can be set via config, extend the error with a hint to set the proper config value
+	// If a required field is missing and the value can be set via config, extend the error with a hint to set the proper config value
 	name := requiredFieldRegex.FindStringSubmatch(reason)
 	if len(name) == 2 {
 		field := res.Schema.Fields[name[1]]

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1377,7 +1377,7 @@ func TestFailureReasonForMissingRequiredFields(t *testing.T) {
 				Schema: &ResourceInfo{
 					Tok: tokens.NewTypeToken("module", "importableResource"),
 					Fields: map[string]*SchemaInfo{
-						"input_y": {
+						"inputY": {
 							Default: &DefaultInfo{
 								Config: "input_y_config",
 							},
@@ -1408,12 +1408,12 @@ func TestFailureReasonForMissingRequiredFields(t *testing.T) {
 	assert.Equal(t, 2, len(failures))
 
 	x, y := failures[0].Reason, failures[1].Reason
-	if strings.Contains(x, "input_y") {
+	if strings.Contains(x, "inputY") {
 		x, y = y, x
 	}
 
 	// Check that Y error reason has been amended with a hint about the config, while X reason is unaffected
-	assert.False(t, strings.Contains(x, "pulumi config"), "No mention of pulumi config expected in '%s'", x)
-	assert.True(t, strings.Contains(y, "'pulumi config set test:input_y_config <value>'"),
-		"Expected a hint of how to set the property value via a config command in '%s'", y)
+	assert.Equal(t, "Missing required property 'inputX'", x)
+	assert.Equal(t, "Missing required property 'inputY'. Either set it explicitly or configure it "+
+		"with 'pulumi config set test:input_y_config <value>'.", y)
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1392,7 +1392,8 @@ func TestFailureReasonForMissingRequiredFields(t *testing.T) {
 	urn := resource.NewURN("s", "pr", "pa", "importableResource", "n")
 
 	// Pass no input values
-	pulumiIns, err := plugin.MarshalProperties(resource.NewPropertyMapFromMap(map[string]interface{}{}), plugin.MarshalOptions{})
+	pulumiIns, err := plugin.MarshalProperties(
+		resource.NewPropertyMapFromMap(map[string]interface{}{}), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 
 	// Check the inputs
@@ -1413,5 +1414,6 @@ func TestFailureReasonForMissingRequiredFields(t *testing.T) {
 
 	// Check that Y error reason has been amended with a hint about the config, while X reason is unaffected
 	assert.False(t, strings.Contains(x, "pulumi config"), "No mention of pulumi config expected in '%s'", x)
-	assert.True(t, strings.Contains(y, "'pulumi config set test:input_y_config <value>'"), "Expected a hint of how to set the property value via a config command in '%s'", y)
+	assert.True(t, strings.Contains(y, "'pulumi config set test:input_y_config <value>'"),
+		"Expected a hint of how to set the property value via a config command in '%s'", y)
 }


### PR DESCRIPTION
Fixes #400 

I'm not very happy about the fact that I had to parse the error message coming from TF and put the logic of checking the config default very far from where it already resides (`MakeTerraformInputs`). However, I don't see another place where we can reliably inject into the pipeline and have no false-positives.