### PR TITLE
Use TF package name when emitting attribution

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -165,10 +165,10 @@ var (
 	docsBaseURL    = "https://github.com/terraform-providers/terraform-provider-%s/blob/master/website/docs"
 	docsDetailsURL = docsBaseURL + "/%s/%s.html.markdown"
 
-	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-%[1]s)
+	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-%[2]s)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
 > first check the [` + "`pulumi/pulumi-%[1]s`" + ` repo](https://github.com/pulumi/pulumi-%[1]s/issues); however, if that doesn't turn up anything,
-> please consult the source [` + "`terraform-providers/terraform-provider-%[1]s`" + ` repo](https://github.com/terraform-providers/terraform-provider-%[1]s/issues).`
+> please consult the source [` + "`terraform-providers/terraform-provider-%[2]s`" + ` repo](https://github.com/terraform-providers/terraform-provider-%[2]s/issues).`
 )
 
 // groupLines groups a collection of strings, a, by a given separator, sep.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -222,7 +222,7 @@ func (g *goGenerator) ensurePackageComment(mod *module, dir string) error {
 	w.Writefmtln("// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.", pkg)
 	w.Writefmtln("//")
 
-	readme := fmt.Sprintf(standardDocReadme, g.pkg)
+	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name)
 	for _, line := range strings.Split(readme, "\n") {
 		w.Writefmtln("// %s", line)
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -237,7 +237,7 @@ func (g *nodeJSGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name)
 	return nil
 }
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -237,7 +237,7 @@ func (g *pythonGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name)
 	return nil
 }
 


### PR DESCRIPTION
We were assuming the Pulumi package name and Terraform Provider name were the same, but there are cases where that's not the case, such as with `pulumi-azure`'s use of `terraform-provider-azurerm`.

Part of https://github.com/pulumi/docs/issues/1395