### PR TITLE
Change how Tfgen deals with resources called Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG details important changes made in each version of the
 
 - Terraform-based providers can now communicate detailed information about the difference between a resource's desired and actual state during a Pulumi update.
 - Add the ability to inject CustomTimeouts into the InstanceDiff during a pulumi update.
+- Change how Tfgen deals with package classes that are named Index to make them index_.ts
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -475,7 +475,16 @@ func (g *nodeJSGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType
 func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (string, error) {
 	// Create a resource module file into which all of this resource's types will go.
 	name := res.name
-	w, file, err := g.openWriter(mod, lowerFirst(name)+".ts", true)
+	filename := lowerFirst(name)
+
+	// We need to check if the resource is called index or utilities. If so then we will have problems
+	// based on the fact that we need to generate an index.ts based on the package contents
+	// Therefore, we are going to append _ into the name to allow us to continue
+	if filename == "index" || filename == "utilities" {
+		filename = fmt.Sprintf("%s_", filename)
+	}
+
+	w, file, err := g.openWriter(mod, filename+".ts", true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We have an issue that Index.ts is a reserves filename in NodeJS
language generation for the contents of the package. So if the resource
is of type Index, we rename it Index_.ts so that it can be included

This allows us to generate the package for GCP Firestore

```
// *** WARNING: this file was generated by the Pulumi Terraform Bridge (tfgen) Tool. ***
// *** Do not edit by hand unless you're certain you know what you are doing! ***

// Export members:
export * from "./index_";
```

This was broken before and we could not use Firestore Indexes