### PR TITLE
Treat sensitive outputs as secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG details important changes made in each version of the
 - Change how Tfgen deals with package classes that are named Index to make them index_.ts
 - Protect against panic in provider Create with InstanceState Meta initialization
 - Use of the `RemoteStateReference` resource no longer results in a panic if the configured remote state cannot be accessed.
+- Treat sensitive outputs as secrets.
 
 ## v0.18.3 (Released June 20, 2019)
 


### PR DESCRIPTION
Fixes: #406

When an output is marked as sensitive according to the schema, we need
to return this as a Pulumi secret