### PR TITLE
Enabling the ability for the Marshalling of Secrets in outputs

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -514,7 +514,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	// After all is said and done, we need to go back and return only what got populated as a diff from the origin.
 	pinputs := MakeTerraformOutputs(inputs, res.TF.Schema, res.Schema.Fields, assets, false, p.supportsSecrets)
 	minputs, err := plugin.MarshalProperties(pinputs, plugin.MarshalOptions{
-		Label: fmt.Sprintf("%s.inputs", label), KeepUnknowns: true})
+		Label: fmt.Sprintf("%s.inputs", label), KeepUnknowns: true, KeepSecrets: p.supportsSecrets})
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +665,8 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 		reasons = append(reasons, errors.Wrapf(err, "converting result for %s", urn).Error())
 	}
 
-	mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{Label: fmt.Sprintf("%s.outs", label)})
+	mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{Label: fmt.Sprintf("%s.outs", label),
+		KeepSecrets: p.supportsSecrets})
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "marshalling %s", urn).Error())
 	}
@@ -734,7 +735,8 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			return nil, err
 		}
 
-		mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{Label: label + ".state"})
+		mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{Label: label + ".state",
+			KeepSecrets: p.supportsSecrets})
 		if err != nil {
 			return nil, err
 		}
@@ -743,7 +745,8 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		if err != nil {
 			return nil, err
 		}
-		minputs, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{Label: label + ".inputs"})
+		minputs, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{Label: label + ".inputs",
+			KeepSecrets: p.supportsSecrets})
 		if err != nil {
 			return nil, err
 		}
@@ -825,7 +828,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		reasons = append(reasons, errors.Wrapf(err, "converting result for %s", urn).Error())
 	}
 	mprops, err := plugin.MarshalProperties(props, plugin.MarshalOptions{
-		Label: fmt.Sprintf("%s.outs", label)})
+		Label: fmt.Sprintf("%s.outs", label), KeepSecrets: p.supportsSecrets})
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "marshalling %s", urn).Error())
 	}


### PR DESCRIPTION
Part of #427 	

Via CLI:
```
Previewing update (dev):

     Type                  Name                   Plan
 +   pulumi:pulumi:Stack   encrypted-secrets-dev  create
 +   └─ aws:ssm:Parameter  foo                    create

Resources:
    + 2 to create

Updating (dev):

     Type                  Name                   Status
 +   pulumi:pulumi:Stack   encrypted-secrets-dev  created
 +   └─ aws:ssm:Parameter  foo                    created

Outputs:
    value: "[secret]"

Resources:
    + 2 created

Duration: 7s
```

Via checkpoint file
```
{
                "urn": "urn:pulumi:dev::encrypted-secrets::aws:ssm/parameter:Parameter::foo",
                "custom": true,
                "id": "foo-58ce001",
                "type": "aws:ssm/parameter:Parameter",
                "inputs": {
                    "__defaults": [
                        "name",
                        "tier"
                    ],
                    "name": "foo-58ce001",
                    "tier": "Standard",
                    "type": "SecureString",
                    "value": {
                        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
                        "ciphertext": "AAABAHHL2iJu4XKEaaguQnS/RvJcP+XlfY5MwstlxxdYTvC72Q=="
                    }
                },
                "outputs": {
                    "allowedPattern": "",
                    "arn": "arn:aws:ssm:us-east-1:153052954103:parameter/foo-58ce001",
                    "description": "",
                    "id": "foo-58ce001",
                    "keyId": "alias/aws/ssm",
                    "name": "foo-58ce001",
                    "tags": {},
                    "tier": "Standard",
                    "type": "SecureString",
                    "value": {
                        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
                        "ciphertext": "AAABALrta9Syc716HgRzeDb0TH1KMlimgztuPiGUNOWPr4q0Ig=="
                    },
                    "version": 1
                },
                "parent": "urn:pulumi:dev::encrypted-secrets::pulumi:pulumi:Stack::encrypted-secrets-dev",
                "provider": "urn:pulumi:dev::encrypted-secrets::pulumi:providers:aws::default::c2915197-f245-4d96-b068-97479a871a8d",
                "propertyDependencies": {
                    "type": null,
                    "value": null
                },
                "customTimeouts": {
                    "Create": 0,
                    "Update": 0,
                    "Delete": 0
                }
            }
``