### PR TITLE
Add support in pulumi-terraform for providing aliases for a particular resource.

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -84,7 +84,7 @@ type ResourceInfo struct {
 	IDFields            []string               // an optional list of ID alias fields.
 	Docs                *DocInfo               // overrides for finding and mapping TF docs.
 	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
-	Aliases             []AliasInfo            // sliases for this resources, if any.
+	Aliases             []AliasInfo            // aliases for this resources, if any.
 }
 
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -63,6 +63,18 @@ func (info ProviderInfo) GetGitHubOrg() string {
 	return info.GitHubOrg
 }
 
+// AliasInfo is a partial description of prior named used for a resource. It can be processed in the
+// context of a resource creation to determine what the full aliased URN would be.
+//
+// It can be used by Pulumi resource providers to change the aspects of it (i.e. what module it is
+// contained in), without causing resources to be recreated for customers who migrate from the
+// original resource to the current resource.
+type AliasInfo struct {
+	Name    *string
+	Type    *string
+	Project *string
+}
+
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.
@@ -72,6 +84,7 @@ type ResourceInfo struct {
 	IDFields            []string               // an optional list of ID alias fields.
 	Docs                *DocInfo               // overrides for finding and mapping TF docs.
 	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
+	Aliases             []AliasInfo            // sliases for this resources, if any.
 }
 
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -665,7 +665,7 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 				w.Writefmt(", ")
 			}
 
-			writeAlias(w, alias)
+			g.writeAlias(w, alias)
 		}
 
 		w.Writefmtln(`]);`)
@@ -690,7 +690,7 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	return file, nil
 }
 
-func writeAlias(w *tools.GenWriter, alias tfbridge.AliasInfo) {
+func (g *nodeJSGenerator) writeAlias(w *tools.GenWriter, alias tfbridge.AliasInfo) {
 	w.WriteString("{ ")
 	parts := []string{}
 	if alias.Name != nil {

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -694,13 +694,13 @@ func writeAlias(w *tools.GenWriter, alias tfbridge.AliasInfo) {
 	w.WriteString("{ ")
 	parts := []string{}
 	if alias.Name != nil {
-		parts = append(parts, fmt.Sprintf("name: \"%v\"", alias.Name))
+		parts = append(parts, fmt.Sprintf("name: \"%v\"", *alias.Name))
 	}
 	if alias.Project != nil {
-		parts = append(parts, fmt.Sprintf("project: \"%v\"", alias.Project))
+		parts = append(parts, fmt.Sprintf("project: \"%v\"", *alias.Project))
 	}
 	if alias.Type != nil {
-		parts = append(parts, fmt.Sprintf("type: \"%v\"", alias.Type))
+		parts = append(parts, fmt.Sprintf("type: \"%v\"", *alias.Type))
 	}
 
 	for i, part := range parts {

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -656,6 +656,21 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// w.Writefmtln("        }")
 
 	// Now invoke the super constructor with the type, name, and a property map.
+
+	if len(res.info.Aliases) > 0 {
+		w.Writefmt(`        opts = pulumi.withAliases(opts, [`)
+
+		for i, alias := range res.info.Aliases {
+			if i > 0 {
+				w.Writefmt(", ")
+			}
+
+			writeAlias(w, alias)
+		}
+
+		w.Writefmtln(`]);`)
+	}
+
 	w.Writefmtln(`        super(%s.__pulumiType, name, inputs, opts);`, name)
 
 	// Finish the class.
@@ -673,6 +688,30 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	g.emitPlainOldType(w, res.argst, true /*wrapInput*/)
 
 	return file, nil
+}
+
+func writeAlias(w *tools.GenWriter, alias tfbridge.AliasInfo) {
+	w.WriteString("{ ")
+	parts := []string{}
+	if alias.Name != nil {
+		parts = append(parts, fmt.Sprintf("name: \"%v\"", alias.Name))
+	}
+	if alias.Project != nil {
+		parts = append(parts, fmt.Sprintf("project: \"%v\"", alias.Project))
+	}
+	if alias.Type != nil {
+		parts = append(parts, fmt.Sprintf("type: \"%v\"", alias.Type))
+	}
+
+	for i, part := range parts {
+		if i > 0 {
+			w.Writefmt(", ")
+		}
+
+		w.WriteString(part)
+	}
+
+	w.WriteString(" }")
 }
 
 func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (string, error) {

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -658,7 +658,7 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// Now invoke the super constructor with the type, name, and a property map.
 
 	if len(res.info.Aliases) > 0 {
-		w.Writefmt(`        opts = pulumi.mergeOptions(opts, [`)
+		w.Writefmt(`        const aliasOpts = { aliases: [`)
 
 		for i, alias := range res.info.Aliases {
 			if i > 0 {
@@ -668,7 +668,9 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 			g.writeAlias(w, alias)
 		}
 
-		w.Writefmtln(`]);`)
+		w.Writefmtln(`] };`)
+
+		w.Writefmtln(`        opts = opts ? pulumi.mergeOptions(opts, aliasOpts) : aliasOpts;`)
 	}
 
 	w.Writefmtln(`        super(%s.__pulumiType, name, inputs, opts);`, name)

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -658,7 +658,7 @@ func (g *nodeJSGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// Now invoke the super constructor with the type, name, and a property map.
 
 	if len(res.info.Aliases) > 0 {
-		w.Writefmt(`        opts = pulumi.withAliases(opts, [`)
+		w.Writefmt(`        opts = pulumi.mergeOptions(opts, [`)
 
 		for i, alias := range res.info.Aliases {
 			if i > 0 {

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -559,7 +559,7 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 			g.writeAlias(w, alias)
 		}
 
-		w.Writefmtln(`]);`)
+		w.Writefmtln(`])`)
 	}
 
 	// Finally, chain to the base constructor, which will actually register the resource.

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -549,7 +549,9 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// w.Writefmtln("            opts.version = utilities.get_version()")
 
 	if len(res.info.Aliases) > 0 {
-		w.Writefmt(`        opts = pulumi.with_aliases(opts, [`)
+		w.Writefmt(`        if opts is None:`)
+		w.Writefmt(`            opts = pulumi.ResourceOptions()`)
+		w.Writefmt(`            opts = opts.merge_options(opts, [`)
 
 		for i, alias := range res.info.Aliases {
 			if i > 0 {

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -549,9 +549,7 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// w.Writefmtln("            opts.version = utilities.get_version()")
 
 	if len(res.info.Aliases) > 0 {
-		w.Writefmt(`        if opts is None:`)
-		w.Writefmt(`            opts = pulumi.ResourceOptions()`)
-		w.Writefmt(`            opts = opts.merge_options(opts, [`)
+		w.Writefmt(`        alias_opts = ResourceOptions(aliases=[`)
 
 		for i, alias := range res.info.Aliases {
 			if i > 0 {
@@ -562,6 +560,7 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		}
 
 		w.Writefmtln(`])`)
+		w.Writefmtln(`        opts = alias_opts if opts is None else opts.merge(alias_opts)`)
 	}
 
 	// Finally, chain to the base constructor, which will actually register the resource.


### PR DESCRIPTION
Will be used downstream initially in pulumi/aws and pulumi/azure to rename some resources in a non-destructive way for users.