### PR TITLE
Emit warning that pulumi binary not found when installing plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This CHANGELOG details important changes made in each version of the
 - Use of the `RemoteStateReference` resource no longer results in a panic if the configured remote state cannot be accessed.
 - Allow a provider to depend on a specific version of TypeScript.
 - Allow users to specific a specific provider version.
+- Emit an appropriate user warning when Pulumi binary not found in Python setup.py.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -721,7 +721,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	w.Writefmtln("                There was an error installing the %s resource provider plugin.", pack.name)
 	w.Writefmtln("                It looks like `pulumi` is not installed on your system.")
 	w.Writefmtln("                Please visit https://pulumi.com/ to get Pulumi.")
-	w.Writefmtln("                You may try to manually installing the plugin by running")
+	w.Writefmtln("                You may try manually installing the plugin by running")
 	w.Writefmtln("                `pulumi plugin install resource %s ${PLUGIN_VERSION}`", pack.name)
 	w.Writefmtln("                \"\"\")")
 	w.Writefmtln("            else:")

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -720,7 +720,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	w.Writefmtln("                print(\"\"\"")
 	w.Writefmtln("                There was an error installing the %s resource provider plugin.", pack.name)
 	w.Writefmtln("                It looks like `pulumi` is not installed on your system.")
-	w.Writefmtln("                Please visit https://pulumi.com/ to get Pulumi.")
+	w.Writefmtln("                Please visit https://pulumi.com/ to install the Pulumi CLI.")
 	w.Writefmtln("                You may try manually installing the plugin by running")
 	w.Writefmtln("                `pulumi plugin install resource %s ${PLUGIN_VERSION}`", pack.name)
 	w.Writefmtln("                \"\"\")")


### PR DESCRIPTION
Fixes: #392

We don't want to raise an exception to the user, instead, we want
to warn the user that pulumi binary isn't found and want them to
install the plugin by hand after pulumi is installed