### PR TITLE
Add the ability to add a deprecation notice to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This CHANGELOG details important changes made in each version of the
 - Protect against panic in provider Create with InstanceState Meta initialization
 - Use of the `RemoteStateReference` resource no longer results in a panic if the configured remote state cannot be accessed.
 - Allow a provider to depend on a specific version of TypeScript.
-- Allow users to specific a specific provider version.
+- Allow users to specify a specific provider version.
+- Add the ability to deprecate resources and datasources.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -85,13 +85,15 @@ type ResourceInfo struct {
 	Docs                *DocInfo               // overrides for finding and mapping TF docs.
 	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
 	Aliases             []AliasInfo            // aliases for this resources, if any.
+	DeprecationMessage  string                 // message to use in deprecation warning
 }
 
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo struct {
-	Tok    tokens.ModuleMember
-	Fields map[string]*SchemaInfo
-	Docs   *DocInfo // overrides for finding and mapping TF docs.
+	Tok                tokens.ModuleMember
+	Fields             map[string]*SchemaInfo
+	Docs               *DocInfo // overrides for finding and mapping TF docs.
+	DeprecationMessage string   // message to use in deprecation warning
 }
 
 // SchemaInfo contains optional name transformations to apply.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -438,6 +438,11 @@ func (g *goGenerator) emitResourceType(mod *module, res *resourceType) error {
 	if res.doc != "" {
 		g.emitDocComment(w, res.doc, res.docURL, "")
 	}
+	if !res.IsProvider() {
+		if res.info.DeprecationMessage != "" {
+			w.Writefmtln("// Deprecated: %s", res.info.DeprecationMessage)
+		}
+	}
 	w.Writefmtln("type %s struct {", name)
 	w.Writefmtln("\ts *pulumi.ResourceState")
 	w.Writefmtln("}")
@@ -446,6 +451,9 @@ func (g *goGenerator) emitResourceType(mod *module, res *resourceType) error {
 	// Create a constructor function that registers a new instance of this resource.
 	argsType := res.argst.name
 	w.Writefmtln("// New%s registers a new resource with the given unique name, arguments, and options.", name)
+	if res.info.DeprecationMessage != "" {
+		w.Writefmtln("// Deprecated: %s", res.info.DeprecationMessage)
+	}
 	w.Writefmtln("func New%s(ctx *pulumi.Context,", name)
 	w.Writefmtln("\tname string, args *%s, opts ...pulumi.ResourceOpt) (*%s, error) {", argsType, name)
 
@@ -497,6 +505,9 @@ func (g *goGenerator) emitResourceType(mod *module, res *resourceType) error {
 	stateType := res.statet.name
 	w.Writefmtln("// Get%[1]s gets an existing %[1]s resource's state with the given name, ID, and optional", name)
 	w.Writefmtln("// state properties that are used to uniquely qualify the lookup (nil if not required).")
+	if res.info.DeprecationMessage != "" {
+		w.Writefmtln("// Deprecated: %s", res.info.DeprecationMessage)
+	}
 	w.Writefmtln("func Get%s(ctx *pulumi.Context,", name)
 	w.Writefmtln("\tname string, id pulumi.ID, state *%s, opts ...pulumi.ResourceOpt) (*%s, error) {", stateType, name)
 	w.Writefmtln("\tinputs := make(map[string]interface{})")
@@ -573,6 +584,10 @@ func (g *goGenerator) emitResourceFunc(mod *module, fun *resourceFunc) error {
 	// Write the TypeDoc/JSDoc for the data source function.
 	if fun.doc != "" {
 		g.emitDocComment(w, fun.doc, fun.docURL, "")
+	}
+
+	if fun.info.DeprecationMessage != "" {
+		w.Writefmtln("// Deprecated: %s", fun.info.DeprecationMessage)
 	}
 
 	// If the function starts with New or Get, it will conflict; so rename them.

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -457,10 +457,18 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	if res.IsProvider() {
 		baseType = "pulumi.ProviderResource"
 	}
+
+	if !res.IsProvider() && res.info.DeprecationMessage != "" {
+		w.Writefmtln("warnings.warn(\"%s\", DeprecationWarning)", res.info.DeprecationMessage)
+	}
+
 	// Produce a class definition with optional """ comment.
 	w.Writefmtln("class %s(%s):", pyClassName(res.name), baseType)
 	g.emitMembers(w, mod, res)
 
+	if res.info.DeprecationMessage != "" {
+		w.Writefmtln("    warnings.warn(\"%s\", DeprecationWarning)", res.info.DeprecationMessage)
+	}
 	// Now generate an initializer with arguments for all input properties.
 	w.Writefmt("    def __init__(__self__, resource_name, opts=None")
 
@@ -473,6 +481,9 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 	// compatibility, we still emit them, but we don't emit documentation for them.
 	w.Writefmtln(", __name__=None, __opts__=None):")
 	g.emitInitDocstring(w, mod, res)
+	if res.info.DeprecationMessage != "" {
+		w.Writefmtln("        pulumi.log.warn(\"%s is deprecated: %s\")", name, res.info.DeprecationMessage)
+	}
 	w.Writefmtln("        if __name__ is not None:")
 	w.Writefmtln(`            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)`)
 	w.Writefmtln("            resource_name = __name__")
@@ -616,6 +627,10 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 	}
 	defer contract.IgnoreClose(w)
 
+	if fun.info.DeprecationMessage != "" {
+		w.Writefmtln("warnings.warn(\"%s\", DeprecationWarning)", fun.info.DeprecationMessage)
+	}
+
 	// If there is a return type, emit it.
 	if fun.retst != nil {
 		g.emitPlainOldType(w, fun.retst)
@@ -633,6 +648,10 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 	// Write the TypeDoc/JSDoc for the data source function.
 	if fun.doc != "" {
 		g.emitDocComment(w, fun.doc, fun.docURL, "    ")
+	}
+
+	if fun.info.DeprecationMessage != "" {
+		w.Writefmtln("    pulumi.log.warn(\"%s is deprecated: %s\")", name, fun.info.DeprecationMessage)
 	}
 
 	// Copy the function arguments into a dictionary.


### PR DESCRIPTION
Based on being able to add a DeprecationMessage to the schema, e.g. :

```
"aws_s3_bucket": {
	DeprecationMessage: "use aws_s3_new_bucket instead",
	Tok:                awsResource(s3Mod, "Bucket"),
},
```

We will emit Deprecation decorators across JavaScript, Go and Python langague SDKs. 

As a bonus, for JavaScript and Python, we can get outputs as follows:

```TypeScript
..[$] <()> pulumi up
Previewing update (dev):

     Type                 Name                            Plan       Info
 +   pulumi:pulumi:Stack  aws-ts-deprecation-testing-dev  create     1 warning
 +   └─ aws:s3:Bucket     my-bucket                       create

Diagnostics:
  pulumi:pulumi:Stack (aws-ts-deprecation-testing-dev):
    warning: Bucket is deprecated: use aws_s3_new_bucket instead

Resources:
    + 2 to create
```

```Python
$ pulumi up
Previewing update (dev):

     Type                 Name                            Plan       Info
 +   pulumi:pulumi:Stack  aws-py-deprecation-testing-dev  create     1 warning
 +   └─ aws:s3:Bucket     my-bucket                       create

Diagnostics:
  pulumi:pulumi:Stack (aws-py-deprecation-testing-dev):
    warning: bucket is deprecated: use aws_s3_new_bucket instead

Resources:
    + 2 to create
```