### PR TITLE
Take advantage of synchronous invokes in Python.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This CHANGELOG details important changes made in each version of the
 - Emit an appropriate user warning when Pulumi binary not found in Python setup.py.
 - Add support for suppressing differences between the desired and actual state of a resource via the `ignoreChanges` property.
 - Fix a bug that caused the recalculation of defaults for values that are normalized in resource state.
+- The Python SDK generated for a provider now supports synchronous invokes.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/pulumi-terraform
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/gliderlabs/ssh v0.1.3 // indirect


### PR DESCRIPTION
With these changes, all invokes will now run synchronously. We retain
backwards compatibility with user programs by making the result of each
invoke awaitable.

Because synchronous invokes require that bridged providers depend on a
newer version of the Pulumi Python SDK, these changes also introduce
some basic validation of the Python requirements entry in the provider
info.