### PR TITLE
Rewrite resource and property names in doc generator

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -75,6 +75,13 @@ type AliasInfo struct {
 	Project *string
 }
 
+// ResourceOrDataSourceInfo is a shared interface to ResourceInfo and DataSourceInfo mappings
+type ResourceOrDataSourceInfo interface {
+	GetTok() tokens.Token              // a type token to override the default; "" uses the default.
+	GetFields() map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
+	GetDocs() *DocInfo                 // overrides for finding and mapping TF docs.
+}
+
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.
@@ -88,6 +95,10 @@ type ResourceInfo struct {
 	DeprecationMessage  string                 // message to use in deprecation warning
 }
 
+func (info *ResourceInfo) GetTok() tokens.Token              { return tokens.Token(info.Tok) }
+func (info *ResourceInfo) GetFields() map[string]*SchemaInfo { return info.Fields }
+func (info *ResourceInfo) GetDocs() *DocInfo                 { return info.Docs }
+
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo struct {
 	Tok                tokens.ModuleMember
@@ -95,6 +106,10 @@ type DataSourceInfo struct {
 	Docs               *DocInfo // overrides for finding and mapping TF docs.
 	DeprecationMessage string   // message to use in deprecation warning
 }
+
+func (info *DataSourceInfo) GetTok() tokens.Token              { return tokens.Token(info.Tok) }
+func (info *DataSourceInfo) GetFields() map[string]*SchemaInfo { return info.Fields }
+func (info *DataSourceInfo) GetDocs() *DocInfo                 { return info.Docs }
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -144,8 +144,9 @@ func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte
 }
 
 // mergeDocs adds the docs specified by extractDoc from sourceFrom into the targetDocs
-func mergeDocs(g *generator, info tfbridge.ResourceOrDataSourceInfo, org string, provider string, resourcePrefix string, kind DocKind,
-	targetDocs map[string]string, sourceFrom string, extractDocs func(d parsedDoc) map[string]string) error {
+func mergeDocs(g *generator, info tfbridge.ResourceOrDataSourceInfo, org string, provider string,
+	resourcePrefix string, kind DocKind, targetDocs map[string]string, sourceFrom string,
+	extractDocs func(d parsedDoc) map[string]string) error {
 
 	if sourceFrom != "" {
 		sourceDocs, err := getDocsForProvider(g, org, provider, resourcePrefix, kind, sourceFrom, nil)

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -57,7 +57,7 @@ const (
 
 // getDocsForProvider extracts documentation details for the given package from
 // TF website documentation markdown content
-func getDocsForProvider(language language, org string, provider string, resourcePrefix string, kind DocKind,
+func getDocsForProvider(g *generator, org string, provider string, resourcePrefix string, kind DocKind,
 	rawname string, docinfo *tfbridge.DocInfo) (parsedDoc, error) {
 	repo, err := getRepoDir(org, provider)
 	if err != nil {
@@ -85,14 +85,14 @@ func getDocsForProvider(language language, org string, provider string, resource
 		return parsedDoc{}, nil
 	}
 
-	doc, err := parseTFMarkdown(language, kind, string(markdownBytes), resourcePrefix, rawname)
+	doc, err := parseTFMarkdown(g, kind, string(markdownBytes), resourcePrefix, rawname)
 	if err != nil {
 		return parsedDoc{}, nil
 	}
 
 	if docinfo != nil {
 		// Merge Attributes from source into target
-		if err := mergeDocs(language, org, provider, resourcePrefix, kind, doc.Attributes, docinfo.IncludeAttributesFrom,
+		if err := mergeDocs(g, org, provider, resourcePrefix, kind, doc.Attributes, docinfo.IncludeAttributesFrom,
 			func(s parsedDoc) map[string]string {
 				return s.Attributes
 			},
@@ -101,7 +101,7 @@ func getDocsForProvider(language language, org string, provider string, resource
 		}
 
 		// Merge Arguments from source into Attributes of target
-		if err := mergeDocs(language, org, provider, resourcePrefix, kind, doc.Attributes,
+		if err := mergeDocs(g, org, provider, resourcePrefix, kind, doc.Attributes,
 			docinfo.IncludeAttributesFromArguments,
 			func(s parsedDoc) map[string]string {
 				return s.Arguments
@@ -111,7 +111,7 @@ func getDocsForProvider(language language, org string, provider string, resource
 		}
 
 		// Merge Arguments from source into target
-		if err := mergeDocs(language, org, provider, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom,
+		if err := mergeDocs(g, org, provider, provider, kind, doc.Arguments, docinfo.IncludeArgumentsFrom,
 			func(s parsedDoc) map[string]string {
 				return s.Arguments
 			},
@@ -138,11 +138,11 @@ func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte
 }
 
 // mergeDocs adds the docs specified by extractDoc from sourceFrom into the targetDocs
-func mergeDocs(language language, org string, provider string, resourcePrefix string, kind DocKind,
+func mergeDocs(g *generator, org string, provider string, resourcePrefix string, kind DocKind,
 	targetDocs map[string]string, sourceFrom string, extractDocs func(d parsedDoc) map[string]string) error {
 
 	if sourceFrom != "" {
-		sourceDocs, err := getDocsForProvider(language, org, provider, resourcePrefix, kind, sourceFrom, nil)
+		sourceDocs, err := getDocsForProvider(g, org, provider, resourcePrefix, kind, sourceFrom, nil)
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func getDocsIndexURL(p string) string {
 
 // parseTFMarkdown takes a TF website markdown doc and extracts a structured representation for use in
 // generating doc comments
-func parseTFMarkdown(language language, kind DocKind, markdown, resourcePrefix, rawname string) (parsedDoc, error) {
+func parseTFMarkdown(g *generator, kind DocKind, markdown, resourcePrefix, rawname string) (parsedDoc, error) {
 	ret := parsedDoc{
 		Arguments:  make(map[string]string),
 		Attributes: make(map[string]string),
@@ -282,7 +282,7 @@ func parseTFMarkdown(language language, kind DocKind, markdown, resourcePrefix, 
 			// bail out, but most errors are ignorable and just lead to us skipping one section.
 			var skippableExamples bool
 			var err error
-			subsection, skippableExamples, err = parseExamples(language, subsection)
+			subsection, skippableExamples, err = parseExamples(g.language, subsection)
 			if err != nil {
 				return parsedDoc{}, err
 			} else if skippableExamples && !headerIsArgsReference &&
@@ -380,7 +380,7 @@ func parseTFMarkdown(language language, kind DocKind, markdown, resourcePrefix, 
 		}
 	}
 
-	return cleanupDoc(ret), nil
+	return cleanupDoc(g, ret), nil
 }
 
 var (
@@ -568,17 +568,17 @@ func convertHCL(hcl string) (string, string, error) {
 	return stdout.String(), "", nil
 }
 
-func cleanupDoc(doc parsedDoc) parsedDoc {
+func cleanupDoc(g *generator, doc parsedDoc) parsedDoc {
 	newargs := make(map[string]string, len(doc.Arguments))
 	for k, v := range doc.Arguments {
-		newargs[k] = cleanupText(v)
+		newargs[k] = cleanupText(g, v)
 	}
 	newattrs := make(map[string]string, len(doc.Attributes))
 	for k, v := range doc.Attributes {
-		newattrs[k] = cleanupText(v)
+		newattrs[k] = cleanupText(g, v)
 	}
 	return parsedDoc{
-		Description: cleanupText(doc.Description),
+		Description: cleanupText(g, doc.Description),
 		Arguments:   newargs,
 		Attributes:  newattrs,
 		URL:         doc.URL,
@@ -586,11 +586,12 @@ func cleanupDoc(doc parsedDoc) parsedDoc {
 }
 
 var markdownLink = regexp.MustCompile(`\[([^\]]*)\]\(([^\)]*)\)`)
+var codeLikeSingleWord = regexp.MustCompile("([\\s`\"\\[])(([0-9a-z]+_)+[0-9a-z]+)([\\s`\"\\]])")
 
 const elidedDocComment = "<elided>"
 
 // cleanupText processes markdown strings from TF docs and cleans them for inclusion in Pulumi docs
-func cleanupText(text string) string {
+func cleanupText(g *generator, text string) string {
 	// Remove incorrect documentation that should have been cleaned up in our forks.
 	// TODO: fail the build in the face of such text, once we have a processes in place.
 	if strings.Contains(text, "Terraform") || strings.Contains(text, "terraform") {
@@ -619,6 +620,35 @@ func cleanupText(text string) string {
 		// Relative URL to the current page, can't be resolved currently so remove the link.
 		// Note: This throws away potentially valuable information in the name of not having broken links.
 		return parts[1]
+	})
+
+	// Fixup resource and property name references
+	text = codeLikeSingleWord.ReplaceAllStringFunc(text, func(match string) string {
+		parts := codeLikeSingleWord.FindStringSubmatch(match)
+		name := parts[2]
+		info, hasResourceInfo := g.info.Resources[name]
+		if hasResourceInfo {
+			// This is a resource name
+			resname, mod := resourceName(g.info.GetResourcePrefix(), name, info, false)
+			modname := extractModuleName(mod)
+			switch g.language {
+			case golang, python:
+				// Use `ec2.Instance` format
+				return parts[1] + modname + "." + resname + parts[4]
+			default:
+				// User `aws.ec2.Instance` format`
+				return parts[1] + g.info.GetResourcePrefix() + "." + modname + "." + resname + parts[4]
+			}
+		}
+		// Else just treat as a property name
+		switch g.language {
+		case nodeJS, golang:
+			// Use `camelCase` format
+			pname := propertyName(name, nil, nil)
+			return parts[1] + pname + parts[4]
+		default:
+			return match
+		}
 	})
 
 	// Finally, trim any trailing blank lines and return the result.

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -17,6 +17,7 @@ package tfgen
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,15 +34,27 @@ func TestURLRewrite(t *testing.T) {
 		},
 		{
 			Input:    "It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by [`aws_lb_listener`](lb_listener.html)).", // nolint: lll
-			Expected: "It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by `aws_lb_listener`).",                     // nolint: lll
+			Expected: "It's recommended to specify `createBeforeDestroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by `awsLbListener`).",                         // nolint: lll
 		},
 		{
-			Input:    "The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`",                         // nolint: lll
-			Expected: "The execution ARN to be used in [`lambda_permission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)'s `source_arn`", // nolint: lll
+			Input:    "The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`",                       // nolint: lll
+			Expected: "The execution ARN to be used in [`lambdaPermission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)'s `sourceArn`", // nolint: lll
+		},
+		{
+			Input:    "See google_container_node_pool for schema.",
+			Expected: "See google.container.NodePool for schema.",
 		},
 	}
 
+	g, err := newGenerator("google", "0.1.2", "nodejs", tfbridge.ProviderInfo{
+		Name: "google",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"google_container_node_pool": {Tok: "google:container/nodePool:NodePool"},
+		},
+	}, "", "")
+	assert.NoError(t, err)
+
 	for _, test := range tests {
-		assert.Equal(t, test.Expected, cleanupText(test.Input))
+		assert.Equal(t, test.Expected, cleanupText(g, test.Input))
 	}
 }

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -55,6 +55,6 @@ func TestURLRewrite(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, test := range tests {
-		assert.Equal(t, test.Expected, cleanupText(g, test.Input))
+		assert.Equal(t, test.Expected, cleanupText(g, nil, test.Input))
 	}
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -45,7 +45,7 @@ const (
 )
 
 type generator struct {
-	pkg         string                // the TF package name (e.g. `aws`)
+	pkg         string                // the Pulum package name (e.g. `gcp`)
 	version     string                // the package version.
 	language    language              // the language runtime to generate.
 	info        tfbridge.ProviderInfo // the provider info for customizing code generation
@@ -548,7 +548,7 @@ func (g *generator) gatherResource(rawname string,
 	var parsedDocs parsedDoc
 	if !isProvider {
 		pd, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-			g.info.GetResourcePrefix(), ResourceDocs, rawname, info.Docs)
+			g.info.GetResourcePrefix(), ResourceDocs, rawname, info)
 		if err != nil {
 			return "", nil, err
 		}
@@ -701,7 +701,7 @@ func (g *generator) gatherDataSource(rawname string,
 
 	// Collect documentation information for this data source.
 	parsedDocs, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info.Docs)
+		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Part of #398.

See:
- GCP: https://github.com/pulumi/pulumi-gcp/compare/lukehoban/namerewriting
- AWS: https://github.com/pulumi/pulumi-aws/compare/lukehoban/namerewriting
- Azure: https://github.com/pulumi/pulumi-azure/compare/lukehoban/namerewriting