### PR TITLE
Ignore state-only diffs.

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -46,7 +46,7 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	attrs, meta, err := MakeTerraformAttributes(res, stateMap, sch, info, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
-	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, nil, resource.PropertyMap{}, false)
+	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
 	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"},

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -33,8 +33,7 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	res := &schema.Resource{
 		Schema: sch,
 		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
-			d.SetNewComputed("outp")
-			return nil
+			return d.SetNewComputed("outp")
 		},
 	}
 	provider := &schema.Provider{
@@ -47,7 +46,7 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	attrs, meta, err := MakeTerraformAttributes(res, stateMap, sch, info, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
-	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, resource.PropertyMap{}, false)
+	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, nil, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
 	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"},

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -30,7 +30,13 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	stateMap := resource.NewPropertyMapFromMap(state)
 
 	// Fake up a TF resource and a TF provider.
-	res := &schema.Resource{Schema: sch}
+	res := &schema.Resource{
+		Schema: sch,
+		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
+			d.SetNewComputed("outp")
+			return nil
+		},
+	}
 	provider := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"resource": res,


### PR DESCRIPTION
It is possible for a Terraform diff to contain diffs to properties that
are only present in the state. These diffs typically exist because
`CustomizeDiff` has marked a computed property as differing (see e.g.
the `last_modified` property of `aws_lambda_function`). We do not care
about these diffs and can safely remove them from the detailed diff.