### PR TITLE
Reflect assets from inputs to outputs.

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -41,7 +41,7 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	attrs, meta, err := MakeTerraformAttributes(res, stateMap, sch, info, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
-	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, resource.PropertyMap{}, false)
+	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, nil, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
 	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"},


### PR DESCRIPTION
If an input property value `p` is an asset or archive, reflect the same
asset or archive into the output property `p` if it exists.

This fixes spurious diffs due to differences between the temporary
paths we use for spilling assets when a stack is updated across
machines/reboots/etc.