### PR TITLE
Drop examples that contain NYI features.

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -574,7 +574,11 @@ func convertHCL(hcl string) (string, string, error) {
 		return "", stderr.String(), errors.Wrap(err, "converting HCL to Pulumi code")
 	}
 
-	return stdout.String(), "", nil
+	result := stdout.String()
+	if result.Index("tf2pulumi error") != -1 {
+		return "", "", errors.New("tf2pulumi error in generated code")
+	}
+	return result, "", nil
 }
 
 func cleanupDoc(g *generator, info tfbridge.ResourceOrDataSourceInfo, doc parsedDoc) parsedDoc {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -575,7 +575,7 @@ func convertHCL(hcl string) (string, string, error) {
 	}
 
 	result := stdout.String()
-	if result.Index("tf2pulumi error") != -1 {
+	if strings.Index(result, "tf2pulumi error") != -1 {
 		return "", "", errors.New("tf2pulumi error in generated code")
 	}
 	return result, "", nil

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -575,7 +575,7 @@ func convertHCL(hcl string) (string, string, error) {
 	}
 
 	result := stdout.String()
-	if strings.Index(result, "tf2pulumi error") != -1 {
+	if strings.Contains(result, "tf2pulumi error") {
 		return "", "", errors.New("tf2pulumi error in generated code")
 	}
 	return result, "", nil


### PR DESCRIPTION
`tf2pulumi` does not yet support the complete set of Terraform features.
Drop any examples that use these unsupported features.

Fixes https://github.com/pulumi/docs/issues/1568.