### PR TITLE
Set delete-before-replace for manually-named resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This CHANGELOG details important changes made in each version of the
 - The Python SDK generated for a provider now supports calling `SomeResource.get(...)` to create a
   resource with the state of existing cloud resource.
 - Generate named nested types with doc comments instead of anonymous inline expansions for TypeScript.
+- Set `DeleteBeforeReplace` for resources that are not auto-named.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -608,8 +608,8 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		}
 	}
 
-	hasAutoName := isAutoNamed(news, res.TF.Schema, res.Schema.Fields)
-	deleteBeforeReplace := len(replaces) > 0 && (res.Schema.DeleteBeforeReplace || !hasAutoName)
+	deleteBeforeReplace := len(replaces) > 0 &&
+		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, res.TF.Schema, res.Schema.Fields))
 
 	return &pulumirpc.DiffResponse{
 		Changes:             changes,

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -24,7 +24,7 @@ import (
 	"github.com/golang/glog"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	pbstruct "github.com/golang/protobuf/ptypes/struct"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/pkg/errors"
@@ -582,9 +582,10 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 			properties = append(properties, k)
 
 			switch d.Kind {
-			case pulumirpc.PropertyDiff_ADD_REPLACE:
-			case pulumirpc.PropertyDiff_UPDATE_REPLACE:
-			case pulumirpc.PropertyDiff_DELETE_REPLACE:
+			case pulumirpc.PropertyDiff_ADD_REPLACE,
+				pulumirpc.PropertyDiff_UPDATE_REPLACE,
+				pulumirpc.PropertyDiff_DELETE_REPLACE:
+
 				replaces = append(replaces, k)
 				if replaced == nil {
 					replaced = make(map[string]bool)
@@ -607,11 +608,14 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		}
 	}
 
+	hasAutoName := isAutoNamed(news, res.TF.Schema, res.Schema.Fields)
+	deleteBeforeReplace := len(replaces) > 0 && (res.Schema.DeleteBeforeReplace || !hasAutoName)
+
 	return &pulumirpc.DiffResponse{
 		Changes:             changes,
 		Replaces:            replaces,
 		Stables:             stables,
-		DeleteBeforeReplace: len(replaces) > 0 && res.Schema.DeleteBeforeReplace,
+		DeleteBeforeReplace: deleteBeforeReplace,
 		Diffs:               properties,
 		DetailedDiff:        detailedDiff,
 		HasDetailedDiff:     true,

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1596,3 +1596,128 @@ func TestAssetRoundtrip(t *testing.T) {
 		"inputA": asset,
 	}).DeepEquals(outs))
 }
+
+func TestDeleteBeforeReplaceAutoname(t *testing.T) {
+	tfProvider := makeTestTFProvider(
+		map[string]*schema.Schema{
+			"input_a": {Type: schema.TypeString, Required: true},
+			"input_b": {Type: schema.TypeString, Required: true, ForceNew: true},
+		},
+		func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			return []*schema.ResourceData{d}, nil
+		})
+
+	tfres := tfProvider.ResourcesMap["importable_resource"]
+	tfres.Create = func(d *schema.ResourceData, meta interface{}) error {
+		d.SetId("MyID")
+		return nil
+	}
+	tfres.Update = func(d *schema.ResourceData, meta interface{}) error {
+		return nil
+	}
+
+	p := &Provider{
+		tf: tfProvider,
+		resources: map[tokens.Type]Resource{
+			"importableResource": {
+				TF:     tfProvider.ResourcesMap["importable_resource"],
+				TFName: "importable_resource",
+				Schema: &ResourceInfo{
+					Tok: tokens.NewTypeToken("module", "importableResource"),
+					Fields: map[string]*SchemaInfo{
+						"input_a": AutoName("inputA", 64),
+					},
+				},
+			},
+		},
+	}
+
+	urn := resource.NewURN("s", "pr", "pa", "importableResource", "myResource")
+
+	// Step 1: create and check an input bag. This input bag will use an auto-name.
+	pulumiIns, err := plugin.MarshalProperties(resource.NewPropertyMapFromMap(map[string]interface{}{
+		"inputB": "foo",
+	}), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	checkResp, err := p.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  string(urn),
+		News: pulumiIns,
+	})
+	assert.NoError(t, err)
+
+	// Step 2: create a resource using the checked input bag. The inputs should be smuggled along with the state.
+	createResp, err := p.Create(context.Background(), &pulumirpc.CreateRequest{
+		Urn:        string(urn),
+		Properties: checkResp.GetInputs(),
+	})
+	assert.NoError(t, err)
+
+	// Step 3: make a new property bag that changes a force-new property and diff the resource. The result should not
+	// be delete-before-create.
+	pulumiIns, err = plugin.MarshalProperties(resource.NewPropertyMapFromMap(map[string]interface{}{
+		"inputB": "bar",
+	}), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	checkResp, err = p.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  string(urn),
+		Olds: createResp.GetProperties(),
+		News: pulumiIns,
+	})
+	assert.NoError(t, err)
+
+	diffResp, err := p.Diff(context.Background(), &pulumirpc.DiffRequest{
+		Id:   "MyID",
+		Urn:  string(urn),
+		Olds: createResp.GetProperties(),
+		News: checkResp.GetInputs(),
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, len(diffResp.GetReplaces()) > 0)
+	assert.False(t, diffResp.GetDeleteBeforeReplace())
+
+	// Step 4: make another property bag that sets a value for the name and changes a force-new property and then diff
+	// the resource. The result should indicate delete-before-replace.
+	pulumiIns, err = plugin.MarshalProperties(resource.NewPropertyMapFromMap(map[string]interface{}{
+		"inputA": "myResource",
+		"inputB": "bar",
+	}), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	checkResp, err = p.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  string(urn),
+		Olds: createResp.GetProperties(),
+		News: pulumiIns,
+	})
+	assert.NoError(t, err)
+
+	diffResp, err = p.Diff(context.Background(), &pulumirpc.DiffRequest{
+		Id:   "MyID",
+		Urn:  string(urn),
+		Olds: createResp.GetProperties(),
+		News: checkResp.GetInputs(),
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, len(diffResp.GetReplaces()) > 0)
+	assert.True(t, diffResp.GetDeleteBeforeReplace())
+
+	// Step 5: delete the defaults list from the checked inputs and re-run the diff. The result should not indicate
+	// delete-before-replace. This tests the back-compat scenario.
+	checkedIns, err := plugin.UnmarshalProperties(checkResp.GetInputs(), plugin.MarshalOptions{})
+	assert.NoError(t, err)
+	delete(checkedIns, defaultsKey)
+	marshaledIns, err := plugin.MarshalProperties(checkedIns, plugin.MarshalOptions{})
+	assert.NoError(t, err)
+
+	diffResp, err = p.Diff(context.Background(), &pulumirpc.DiffRequest{
+		Id:   "MyID",
+		Urn:  string(urn),
+		Olds: createResp.GetProperties(),
+		News: marshaledIns,
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, len(diffResp.GetReplaces()) > 0)
+	assert.False(t, diffResp.GetDeleteBeforeReplace())
+
+}


### PR DESCRIPTION
Determine if a resource is auto-named by checking its list of top-level
defaults for a property that was populated by a default value that is an
autoname. If the defaults list is missing, consider the resource
auto-named for better backwards compatibility.

These changes also fix a bug in the logic that determined the legacy
replaces list.

Fixes #383.