### PR TITLE
Accept Archives everywhere Assets are accepted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This CHANGELOG details important changes made in each version of the
   resource with the state of existing cloud resource.
 - Generate named nested types with doc comments instead of anonymous inline expansions for TypeScript.
 - Set `DeleteBeforeReplace` for resources that are not auto-named.
+- Accept archive values everywhere asset values are accepted.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfbridge/assets.go
+++ b/pkg/tfbridge/assets.go
@@ -156,22 +156,24 @@ func (a *AssetTranslation) TranslateAsset(asset *resource.Asset) (interface{}, e
 
 // TranslateArchive translates the given archive using the directives provided by the translation info.
 func (a *AssetTranslation) TranslateArchive(archive *resource.Archive) (interface{}, error) {
-	contract.Assert(a.IsArchive())
-
 	// TODO[pulumi/pulumi#153]: support HashField.
 
 	// Produce either a temp file or an in-memory representation, as requested.
+	format := a.Format
+	if format == resource.NotArchive {
+		format = resource.ZIPArchive
+	}
 	switch a.Kind {
-	case FileArchive:
+	case FileArchive, FileAsset:
 		path, err := translateToFile(archive.Hash, archive.HasContents(), func(w io.Writer) error {
-			return archive.Archive(a.Format, w)
+			return archive.Archive(format, w)
 		})
 		return path, err
-	case BytesArchive:
+	case BytesArchive, BytesAsset:
 		if !archive.HasContents() {
 			return []byte{}, nil
 		}
-		return archive.Bytes(a.Format)
+		return archive.Bytes(format)
 	default:
 		contract.Failf("Unrecognized asset translation kind: %v", a.Kind)
 		return nil, nil

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -435,8 +435,6 @@ func MakeTerraformInput(res *PulumiResource, name string,
 		// We require that there be archive information, otherwise an error occurs.
 		if ps == nil || ps.Asset == nil {
 			return nil, errors.Errorf("unexpected archive %s", name)
-		} else if !ps.Asset.IsArchive() {
-			return nil, errors.Errorf("expected an archive, but %s is not an archive", name)
 		}
 		if assets != nil {
 			_, has := assets[ps]

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -985,6 +985,31 @@ func TestInvalidAsset(t *testing.T) {
 	}, outputs)
 }
 
+func TestArchiveAsAsset(t *testing.T) {
+	assets := make(AssetTable)
+	tfs := map[string]*schema.Schema{
+		"zzz": {Type: schema.TypeString},
+	}
+	ps := map[string]*SchemaInfo{
+		"zzz": {Asset: &AssetTranslation{Kind: FileAsset}},
+	}
+	olds := resource.PropertyMap{}
+	asset, err := resource.NewTextAsset("bar")
+	assert.NoError(t, err)
+	archValue, err := resource.NewAssetArchive(map[string]interface{}{
+		"foo": asset,
+	})
+	assert.NoError(t, err)
+	arch := resource.NewPropertyValue(archValue)
+	props := resource.PropertyMap{
+		"zzz": arch,
+	}
+	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, nil, false, false)
+	assert.NoError(t, err)
+	outputs := MakeTerraformOutputs(inputs, tfs, ps, assets, false, true)
+	assert.True(t, arch.DeepEquals(outputs["zzz"]))
+}
+
 func boolPointer(b bool) *bool {
 	return &b
 }

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1439,7 +1439,11 @@ func tsTypeComplex(module, typeNamePrefix, name string, sch *schema.Schema, info
 				t = fmt.Sprintf("pulumi.Input<%s>", t)
 			}
 		} else if info.Asset != nil {
-			t = "pulumi.asset." + info.Asset.Type()
+			if info.Asset.IsArchive() {
+				t = "pulumi.asset." + info.Asset.Type()
+			} else {
+				t = "pulumi.asset.Asset | pulumi.asset.Archive"
+			}
 
 			if wrapInput {
 				t = fmt.Sprintf("pulumi.Input<%s>", t)

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -123,6 +123,28 @@ var tsTypeTests = []typeTest{
 		expectedOutput: "string",
 		expectedInput:  "pulumi.Input<string | Foo[]>",
 	},
+	{
+		// Asset
+		schema: &schema.Schema{Type: schema.TypeString},
+		info: &tfbridge.SchemaInfo{
+			Asset: &tfbridge.AssetTranslation{
+				Kind: tfbridge.FileAsset,
+			},
+		},
+		expectedOutput: "pulumi.asset.Asset | pulumi.asset.Archive",
+		expectedInput:  "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>",
+	},
+	{
+		// Archive
+		schema: &schema.Schema{Type: schema.TypeString},
+		info: &tfbridge.SchemaInfo{
+			Asset: &tfbridge.AssetTranslation{
+				Kind: tfbridge.FileArchive,
+			},
+		},
+		expectedOutput: "pulumi.asset.Archive",
+		expectedInput:  "pulumi.Input<pulumi.asset.Archive>",
+	},
 }
 
 func Test_TsTypes(t *testing.T) {

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -110,6 +110,7 @@ func (g *pythonGenerator) emitSDKImport(mod *module, w *tools.GenWriter) {
 	w.Writefmtln("import warnings")
 	w.Writefmtln("import pulumi")
 	w.Writefmtln("import pulumi.runtime")
+	w.Writefmtln("from typing import Union")
 	w.Writefmtln("from %s import utilities, tables", g.relativeRootDir(mod))
 	w.Writefmtln("")
 }
@@ -1085,7 +1086,10 @@ func pyType(v *variable) string {
 func pyTypeFromSchema(sch *schema.Schema, info *tfbridge.SchemaInfo) string {
 	// If this is an asset or archive type, return the proper Pulumi SDK type name.
 	if info != nil && info.Asset != nil {
-		return "pulumi." + info.Asset.Type()
+		if info.Asset.IsArchive() {
+			return "pulumi." + info.Asset.Type()
+		}
+		return "Union[pulumi.Asset, pulumi.Archive]"
 	}
 
 	switch sch.Type {


### PR DESCRIPTION
Just what it says on the tin. If no format has been specified in the
asset translation, default to ZIP.

Fixes https://github.com/pulumi/pulumi/issues/280.