### PR TITLE
Correctly handle PEP440 style pre-releases

### DIFF
--- a/pkg/tfgen/generate_python_test.go
+++ b/pkg/tfgen/generate_python_test.go
@@ -51,3 +51,26 @@ func TestPyKeywords(t *testing.T) {
 	assert.Equal(t, pycodegen.PyName("lambda"), "lambda_")
 	assert.Equal(t, pyClassName("True"), "True_")
 }
+
+// Tests our PEP440 to Semver conversion.
+func TestVersionConversion(t *testing.T) {
+	ver, err := pep440VersionToSemver("1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, ver.String(), "1.0.0")
+
+	ver, err = pep440VersionToSemver("1.0.0a123")
+	assert.NoError(t, err)
+	assert.Equal(t, ver.String(), "1.0.0-alpha.123")
+
+	ver, err = pep440VersionToSemver("1.0.0b123")
+	assert.NoError(t, err)
+	assert.Equal(t, ver.String(), "1.0.0-beta.123")
+
+	ver, err = pep440VersionToSemver("1.0.0rc123")
+	assert.NoError(t, err)
+	assert.Equal(t, ver.String(), "1.0.0-rc.123")
+
+	ver, err = pep440VersionToSemver("1.0.0.dev123")
+	assert.NoError(t, err)
+	assert.Equal(t, ver.String(), "1.0.0-dev.123")
+}


### PR DESCRIPTION
Our logic to enforce that the generated reference to the pulumi
package was incorrect when the version of pulumi we requested had
lower bound on a PEP440 style pre-release.

We want to sart using a lower bound of 1.0.0b1 for some packages, so
this fixes up our logic to not barf here by converting the PEP440
versions to semver's correctly before parsing them into a
`semver.Version`