### PR TITLE
Fix Python `Resource.get` parameter comments

### DIFF
--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -1058,9 +1058,8 @@ func (g *pythonGenerator) emitGetDocstring(w *tools.GenWriter, mod *module, res 
 	// "buf" contains the full text of the docstring, without the leading and trailing triple quotes.
 	var buf bytes.Buffer
 
-	// If this resource has documentation, write it at the top of the docstring, otherwise use a generic comment.
-	fmt.Fprintf(&buf, `Get an existing %s resource's state with the given name, id, and optional extra
-properties used to qualify the lookup.`, res.name)
+	fmt.Fprintf(&buf, "Get an existing %s resource's state with the given name, id, and optional extra\n"+
+		"properties used to qualify the lookup.\n", res.name)
 	fmt.Fprintln(&buf, "")
 
 	fmt.Fprintln(&buf, ":param str resource_name: The unique name of the resulting resource.")


### PR DESCRIPTION
There needs to be a blank line between the summary and param docs in order for the parameters to render correctly via Sphinx.

Here's what the docs look like for `Bucket.get` before/after:

https://www.pulumi.com/docs/reference/pkg/python/pulumi_aws/s3/#pulumi_aws.s3.Bucket.get

## Before

<img width="770" alt="Screen Shot 2019-08-24 at 10 19 30 PM" src="https://user-images.githubusercontent.com/710598/63645926-40cff580-c6bd-11e9-8be1-3e304500cf88.png">

## After

<img width="760" alt="Screen Shot 2019-08-24 at 10 43 40 PM" src="https://user-images.githubusercontent.com/710598/63646331-c788d080-c6c5-11e9-8382-eb9d0aa30123.png">

Fixes #477