### PR TITLE
Consume the build-package-docs script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ check_clean_worktree:
 publish_packages:
 	$(call STEP_MESSAGE)
 	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/publish-tfgen-package .
+	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh terraform
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api


### PR DESCRIPTION
Use this script to automatically regenerate the package documentation on
each new release.