### PR TITLE
Provide a mechanism to override nested type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This CHANGELOG details important changes made in each version of the
 - Accept archive values everywhere asset values are accepted.
 - Include nested structure details in Python docstrings.
 - Use `pulumi.InvokeOptions()` when `opts` is `None` for Python data source functions.
+- Provide a mechanism for overriding nested type names.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -122,6 +122,9 @@ type SchemaInfo struct {
 	// alternative types that can be used instead of the override.
 	AltTypes []tokens.Type
 
+	// a type to override when the property is a nested structure.
+	NestedType tokens.Type
+
 	// an optional idemponent transformation, applied before passing to TF.
 	Transform Transformer
 

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1553,6 +1553,10 @@ func tsElemComplexStructureType(module, typeNamePrefix, name string, e *schema.R
 	level++
 
 	typeName := typeNamePrefix + strings.Title(name)
+	// Override the nested type name, if necessary.
+	if info != nil && info.NestedType.Name().String() != "" {
+		typeName = info.NestedType.Name().String()
+	}
 
 	// Values to use when generating an inline anonymous type.
 	whitespace := " "


### PR DESCRIPTION
@stack72, once this is merged, we'll need to update the version of `pulumi-terraform` used by `pulumi-gcp` and I probably cherry-pick https://github.com/pulumi/pulumi-gcp/commit/e6a9945989a42b9973d3adfcf724a83dfef77f11 into your branch?

For the particular GCP property (see linked commit), I decided to go with an `Item` suffix (item in an array), but open to other terms such as (`Entry`, `Element`, etc.) if something else is preferred.

Note: I considered adapting the existing `Type` field on `SchemaInfo` to enable this, but that would have been a much larger change. It was simpler to just add a field specifically for controlling the nested type name.

Part of https://github.com/pulumi/pulumi-gcp/issues/212