### PR TITLE
Remove the need for `pandoc` during the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This CHANGELOG details important changes made in each version of the
 - Include nested structure details in Python docstrings.
 - Use `pulumi.InvokeOptions()` when `opts` is `None` for Python data source functions.
 - Provide a mechanism for overriding nested type names.
+- Remove the need for Pandoc in generating Python SDK readme files.
 
 ## v0.18.3 (Released June 20, 2019)
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -831,7 +831,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	// Generate a readme method which will load README.rst, we use this to fill out the
 	// long_description field in the setup call.
 	w.Writefmtln("def readme():")
-	w.Writefmtln("    with open('README.rst') as f:")
+	w.Writefmtln("    with open('README.md', encoding='utf-8') as f:")
 	w.Writefmtln("        return f.read()")
 	w.Writefmtln("")
 
@@ -842,6 +842,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 		w.Writefmtln("      description='%s',", g.info.Description)
 	}
 	w.Writefmtln("      long_description=readme(),")
+	w.Writefmtln("      long_description_content_type='text/markdown',")
 	w.Writefmtln("      cmdclass={")
 	w.Writefmtln("          'install': InstallPluginCommand,")
 	w.Writefmtln("      },")


### PR DESCRIPTION
Continues the work from https://github.com/pulumi/pulumi/pull/3195
for the pulumi-providers based on TF