### PR TITLE
Fix raw element names in detailed diff.

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -159,6 +159,7 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs *schema
 			psflds = ps.Fields
 		}
 
+		rawElementNames := rawNames || useRawNames(tfs)
 		for k, e := range v.ObjectValue() {
 			var elementPath string
 			if strings.ContainsAny(string(k), `."[]`) {
@@ -167,8 +168,8 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs *schema
 				elementPath = fmt.Sprintf("%s.%s", path, k)
 			}
 
-			en, etf, eps := getInfoFromPulumiName(k, tfflds, psflds, rawNames)
-			visitPropertyValue(name+"."+en, elementPath, e, etf, eps, rawNames || useRawNames(tfs), visitor)
+			en, etf, eps := getInfoFromPulumiName(k, tfflds, psflds, rawElementNames)
+			visitPropertyValue(name+"."+en, elementPath, e, etf, eps, rawElementNames, visitor)
 		}
 	}
 }

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -978,3 +978,42 @@ func TestComputedSetNestedIgnore(t *testing.T) {
 			ignore)
 	}
 }
+
+func TestRawElementNames(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"variables": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": map[string]interface{}{
+				"variables": map[string]interface{}{
+					"DYNAMODB_ROUTE_TABLE_NAME": "foo",
+				},
+			},
+		},
+		map[string]interface{}{
+			"prop": map[string]interface{}{
+				"variables": map[string]interface{}{
+					"DYNAMODB_ROUTE_TABLE_NAME": "bar",
+				},
+			},
+		},
+		map[string]DiffKind{
+			"prop.variables.DYNAMODB_ROUTE_TABLE_NAME": U,
+		})
+}


### PR DESCRIPTION
The code that computes a detailed diff was not properly handling maps
that require raw element names.

Fixes https://github.com/pulumi/pulumi-aws/issues/751.