### PR TITLE
Update data-source codegen to call into new core pulumi functionality that handles sync/async invokes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This CHANGELOG details important changes made in each version of the
 `terraform` provider, the `@pulumi/terraform` Node.js package and the
 `pulumi_terraform` Python package.
 
+## HEAD (Unreleased)
+
+- Do not call liftProperties after invoking a data source.
+
 ## v0.18.4 (Unreleased)
 
 - Initial release of `pulumi_terraform` for Python.

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1033,7 +1033,7 @@ func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc, neste
 	} else {
 		retty = fun.retst.name
 	}
-	w.Writefmtln("export function %s(%sopts?: pulumi.InvokeOptions = {}): Promise<%s> & %s {",
+	w.Writefmtln("export function %s(%sopts: pulumi.InvokeOptions = {}): Promise<%s> & %s {",
 		fun.name, argsig, retty, retty)
 	if fun.info.DeprecationMessage != "" {
 		w.Writefmtln("    pulumi.log.warn(\"%s is deprecated: %s\")", fun.name, fun.info.DeprecationMessage)
@@ -1046,7 +1046,7 @@ func (g *nodeJSGenerator) emitResourceFunc(mod *module, fun *resourceFunc, neste
 
 	w.Writefmtln("")
 
-	w.Writefmtln("    return <any>pulumi.runtime.invoke(\"%s\", {", retty, fun.info.Tok)
+	w.Writefmtln("    return <any>pulumi.runtime.invoke(\"%s\", {", fun.info.Tok)
 	for _, arg := range fun.args {
 		// Pass the argument to the invocation.
 		w.Writefmtln("        \"%[1]s\": args.%[1]s,", arg.name)


### PR DESCRIPTION
WIP.  Part of https://github.com/pulumi/pulumi/issues/3318

The new form looks like this:

```ts
export function getLoadBalancer(args: GetLoadBalancerArgs = {}, opts: pulumi.InvokeOptions = {}): Promise<GetLoadBalancerResult> & GetLoadBalancerResult {
    if (!opts.version) {
        opts = { ...opts, version: utilities.getVersion() };
    }

    return pulumi.runtime.invokeSyncOrAsync("aws:elasticloadbalancingv2/getLoadBalancer:getLoadBalancer", {
        "arn": args.arn,
        "name": args.name,
        "tags": args.tags,
    }, opts);
}
```

The general idea here is that the specific package doesn't need to do anything special.  It just passes along the values as appropriate, requesting that the core pulumi sdk take care of things.

The new pulumi sdk method (`invokeSyncOrAsync`) will dispatch to either the existing `invoke` method if the caller has passed `{async:true}` in their invoke options, or will dispatch to `invokeSync` otherwise.