### PR TITLE
Add an option to only generate async data sources in JavaScript/TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This CHANGELOG details important changes made in each version of the
 - Use `pulumi.InvokeOptions()` when `opts` is `None` for Python data source functions.
 - Provide a mechanism for overriding nested type names.
 
+- Add option to control if only asynchronous data sources should be generated in JS/TS.  Backport of
+  https://github.com/pulumi/pulumi-terraform-bridge/pull/105
+
 ## v0.18.3 (Released June 20, 2019)
 
 - Fixed a bug that caused unnecessary changes if the first operation after upgrading a bridged provider was a `pulumi refresh`.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -245,6 +245,7 @@ type JavaScriptInfo struct {
 	PeerDependencies  map[string]string // NPM peer-dependencies to add to package.json.
 	Overlay           *OverlayInfo      // optional overlay information for augmented code-generation.
 	TypeScriptVersion string            // A specific version of TypeScript to include in package.json.
+	AsyncDataSources  bool              // If true, only generate the async version of data-sources
 }
 
 // PythonInfo contains optional overlay information for Python code-generation.


### PR DESCRIPTION
Backport of https://github.com/pulumi/pulumi-terraform-bridge/pull/105 for providers not on pulumi-terraform-bridge.