### PR TITLE
Fix workspace name in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _(none)_
 
 ---
 
+## Unreleased
+* Fix a bug with `RemoteStateReference`'s remote state backend on Python, where the workspace name was not
+  getting configured correctly (issue [#524](https://github.com/pulumi/pulumi-terraform/issues/524)).
+
 ## v1.1.0 (2019-10-04)
 * Upgrade the Pulumi dependency requirements for NodeJS and Python SDKs
 

--- a/sdk/python/pulumi_terraform/state/remote_state_reference.py
+++ b/sdk/python/pulumi_terraform/state/remote_state_reference.py
@@ -428,8 +428,8 @@ class RemoteBackendArgs:
         self.props["token"] = token
         self.props["hostname"] = hostname
         self.props["workspaces"] = dict()
-        self.props["workspaces"]["workspace_name"] = workspace_name
-        self.props["workspaces"]["workspace_prefix"] = workspace_prefix
+        self.props["workspaces"]["name"] = workspace_name
+        self.props["workspaces"]["prefix"] = workspace_prefix
 
 
 class S3BackendArgs:


### PR DESCRIPTION
The `workspace_` prefix for these keys, when present, leads to:

```
error coercing config from Pulumi format to cty: unexpected attribute "workspaceName"
```

I've manually verified that removing it (a) matches what the Node.js
SDK is producing and (b) lets me correctly read state from a remote
workspace.

I wasn't sure how best to add automated tests for this.

Fixes #524.