### PR TITLE
Use the pulumi-ci AWS profile for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ before_install:
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
     - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
+    - export AWS_SECURITY_TOKEN=${AWS_SESSION_TOKEN}
     # Use the pulumi-ci AWS profile configured by the above script.
-    # This repo runs tests that require access to create resources in AWS.
+    # This repo runs tests that require access to resources in AWS besides just the
+    # get.pulumi.com and rel.pulumi.com S3 buckets.
     - export AWS_PROFILE=pulumi-ci
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ before_install:
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
     - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
-    - export AWS_SECURITY_TOKEN=${AWS_SESSION_TOKEN}
     # Use the pulumi-ci AWS profile configured by the above script.
-    # This repo runs tests that require access to resources in AWS besides just the
-    # get.pulumi.com and rel.pulumi.com S3 buckets.
+    # This repo runs tests that require access to create resources in AWS.
     - export AWS_PROFILE=pulumi-ci
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
     # Use the pulumi-ci AWS profile configured by the above script.
     # This repo runs tests that require access to create resources in AWS.
     - export AWS_PROFILE=pulumi-ci
+    - export AWS_SDK_LOAD_CONFIG=1
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
     - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
+    # Use the pulumi-ci AWS profile configured by the above script.
+    # This repo runs tests that require access to create resources in AWS.
+    - export AWS_PROFILE=pulumi-ci
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -9,15 +9,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
 )
 
-func TestDebugEnvironmentVariables(t *testing.T) {
-	t.Log("Wondering what the environment variables are curently set?")
-	t.Logf("AWS_ACCESS_KEY_ID=%q", os.Getenv("AWS_ACCESS_KEY_ID"))
-	t.Logf("AWS_PROFILE=%q", os.Getenv("AWS_PROFILE"))
-	t.Logf("AWS_SDK_LOAD_CONFIG=%q", os.Getenv("AWS_SDK_LOAD_CONFIG"))
-
-	t.Error("Aborting test so this is in the log files and hopefully easy to read!")
-}
-
 func TestJSLocal011(t *testing.T) {
 	test := getJSBaseOptions().
 		With(integration.ProgramTestOptions{
@@ -51,11 +42,6 @@ func TestJSS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -69,11 +55,6 @@ func TestJSS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -129,11 +110,6 @@ func TestPyS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -147,11 +123,6 @@ func TestPyS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -207,11 +178,6 @@ func TestDotNetS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -225,11 +191,6 @@ func TestDotNetS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -285,11 +246,6 @@ func TestGoS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -303,11 +259,6 @@ func TestGoS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Since we are relying on the AWS credentials file locally, we need to
-				// force this to be used.
-				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -42,6 +42,11 @@ func TestJSS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -55,6 +60,11 @@ func TestJSS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -110,6 +120,11 @@ func TestPyS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -123,6 +138,11 @@ func TestPyS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -178,6 +198,11 @@ func TestDotNetS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -191,6 +216,11 @@ func TestDotNetS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 
@@ -246,6 +276,11 @@ func TestGoS3011(t *testing.T) {
 				"key":        "0-11-state",
 				"region":     "us-west-2",
 			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -259,6 +294,11 @@ func TestGoS3012(t *testing.T) {
 				"bucketName": "pulumi-terraform-remote-state-testing",
 				"key":        "0-12-state",
 				"region":     "us-west-2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Since we are relying on the AWS credentials file locally, we need to
+				// force this to be used.
+				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 			},
 		})
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
 )
 
+func TestDebugEnvironmentVariables(t *testing.T) {
+	t.Log("Wondering what the environment variables are curently set?")
+	t.Logf("AWS_ACCESS_KEY_ID=%q", os.Getenv("AWS_ACCESS_KEY_ID"))
+	t.Logf("AWS_PROFILE=%q", os.Getenv("AWS_PROFILE"))
+	t.Logf("AWS_SDK_LOAD_CONFIG=%q", os.Getenv("AWS_SDK_LOAD_CONFIG"))
+
+	t.Error("Aborting test so this is in the log files and hopefully easy to read!")
+}
+
 func TestJSLocal011(t *testing.T) {
 	test := getJSBaseOptions().
 		With(integration.ProgramTestOptions{


### PR DESCRIPTION
Related to pulumi/home#845.

The `master` branch build failed during the integration test phase due to the AWS creds that were changed with #543 having very limited AWS access. This PR updates the Travis config file to use the CI AWS profile. But that's only one part of it. The other part is that I will update the AWS creds in the Travis settings for this repo to use the corresponding creds that would allow it to use that CI profile.