### PR TITLE
Don't dispatch to pulumi/registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,6 @@ jobs:
         - 14.x
         pythonversion:
         - "3.7"
-  create_docs_build:
-    name: create_docs_build
-    needs: tag_sdk
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.2.0
-      with:
-        repo: pulumi/pulumictl
-    - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since these calls [always fail](https://github.com/pulumi/registry/actions/runs/5694678322/job/15436318005) (and now create `p1` issues for us), we should probably remove them.

We have a handful of other repos that do the same -- pulumi/pulumi-cloud, pulumi/pulumi-archive, others -- so if this makes sense, let me know and I'll happily submit fixes as I notice them.