### PR TITLE
Export PostgresRemoteStateReferenceArgs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -86,18 +86,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -142,13 +142,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish:
     name: publish
     needs: test
@@ -198,13 +198,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -279,13 +279,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   test:
     name: test
     needs: build_sdk
@@ -376,18 +376,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
 name: master
 "on":
   push:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,18 +86,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -142,13 +142,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish:
     name: publish
     needs: test
@@ -198,13 +198,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -279,13 +279,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   test:
     name: test
     needs: build_sdk
@@ -376,18 +376,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
 name: prerelease
 "on":
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,18 +86,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -142,13 +142,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish:
     name: publish
     needs: test
@@ -197,13 +197,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -278,13 +278,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk
@@ -389,18 +389,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
 name: release
 "on":
   push:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -91,18 +91,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification
@@ -169,13 +169,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
   test:
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name
       == github.repository
@@ -270,18 +270,18 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - 6.x
         goversion:
-        - 1.18.x
+        - 1.21.x
         language:
         - nodejs
         - python
         - dotnet
         - go
         nodeversion:
-        - 14.x
+        - 18.x
         pythonversion:
-        - "3.7"
+        - "3.8"
 name: run-acceptance-tests
 "on":
   pull_request:

--- a/examples/localstate-dotnet/LocalState.csproj
+++ b/examples/localstate-dotnet/LocalState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/ossstate-dotnet/OssState.csproj
+++ b/examples/ossstate-dotnet/OssState.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/remote-backend-dotnet/RemoteBackend.csproj
+++ b/examples/remote-backend-dotnet/RemoteBackend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/s3state-dotnet/S3State.csproj
+++ b/examples/s3state-dotnet/S3State.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/dotnet/Pulumi.Terraform.csproj
+++ b/sdk/dotnet/Pulumi.Terraform.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-terraform</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/nodejs/state/index.ts
+++ b/sdk/nodejs/state/index.ts
@@ -25,5 +25,6 @@ export * from "./mantaBackendConfig"
 export * from "./remoteBackendConfig"
 export * from "./remoteStateReference";
 export * from "./s3BackendConfig";
-export * from "./swiftBackendConfig"
-export * from "./ossBackendConfig"
+export * from "./swiftBackendConfig";
+export * from "./ossBackendConfig";
+export * from "./pgBackendConfig";


### PR DESCRIPTION
While working on revamping docs generation using plain typedoc (this is really for the pulumi/pulumi and pulumi/policy nodejs sdks, but some providers like this also use it instead of the newer docs gen), I noticed that `PostgresRemoteStateReferenceArgs` was missing from the output.

I set node to v18 for CI, since older versions are no longer supported. Let me know if you prefer I split that into a separate PR.