### PR TITLE
Goreleaser use --clean instead of --rm-dist

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout
           60m0s
         version: latest
     strategy:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout
           60m0s
         version: latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
This is equivalent and caused by goreleaser changing from v1 to v2.

Fixes https://github.com/pulumi/pulumi-terraform/issues/764