### PR TITLE
Unpin the version of Pulumi used

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,8 +42,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -117,8 +115,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Tar provider binaries
@@ -159,8 +155,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -215,8 +209,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -291,8 +283,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -42,8 +42,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -117,8 +115,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Tar provider binaries
@@ -159,8 +155,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -215,8 +209,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -291,8 +283,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -117,8 +115,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Tar provider binaries
@@ -159,8 +155,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -214,8 +208,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -304,8 +296,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -47,8 +47,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -144,8 +142,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Tar provider binaries
@@ -195,8 +191,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version: v3.108.1
     - name: Setup Node
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
Following up on https://github.com/pulumi/pulumi/pull/16544, we should be able to unpin the version of Pulumi used in CI (originally pinned in https://github.com/pulumi/pulumi-terraform/pull/761 due to https://github.com/pulumi/pulumi/issues/16502).