### PR TITLE
Fix module path

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -4,6 +4,7 @@ major-version: 6
 pulumiVersionFile: .pulumi.version
 providerDefaultBranch: master
 parallel: 3
+modulePath: .
 envOverride:
   PULUMI_API: https://api.pulumi-staging.io
   TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}


### PR DESCRIPTION
Unfortunately our standard module location isn't at the repo root, so this needs to be specified explicitly.

Fixes https://github.com/pulumi/ci-mgmt/issues/1765.