### PR TITLE
Remove golangci-lint "build-tags" configuration.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   timeout: 10m
-  # Enable checking the by default skipped "examples" dirs
-  build-tags:
-  - all
+
 linters:
   enable-all: false
   enable:


### PR DESCRIPTION
Part of #864

Aligning this repo with the convention we follow on other repos. For instance,
https://github.com/pulumi/pulumi-docker-build/blob/main/.golangci.yml.

