### PR TITLE
Opt-out of schema checks

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -5,6 +5,7 @@ pulumiVersionFile: .pulumi.version
 providerDefaultBranch: master
 parallel: 3
 modulePath: .
+noSchema: true # Disable schema check.
 envOverride:
     PULUMI_API: https://api.pulumi-staging.io
     TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}


### PR DESCRIPTION
We currently hard-code this opt-out in ci-mgmt:

https://github.com/pulumi/ci-mgmt/blob/f76cbff100ad8e6e3192b379edb5bcf1f536eb3e/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml#L101

We previously exposed some config for opting out to bridged providers, and I'll be carrying that over to native ones.

This is a no-op for now because I'll merge the ci-mgmt fix after this is in.