### PR TITLE
Inject TFE credentials into build/prerelease/release test steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -315,6 +315,8 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TFE_ORGANIZATION: ${{ steps.esc-secrets.outputs.TFE_ORGANIZATION }}
+        TFE_TOKEN: ${{ steps.esc-secrets.outputs.TFE_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -271,6 +271,8 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TFE_ORGANIZATION: ${{ steps.esc-secrets.outputs.TFE_ORGANIZATION }}
+        TFE_TOKEN: ${{ steps.esc-secrets.outputs.TFE_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,9 @@ jobs:
 
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
-        GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TFE_ORGANIZATION: ${{ steps.esc-secrets.outputs.TFE_ORGANIZATION }}
+        TFE_TOKEN: ${{ steps.esc-secrets.outputs.TFE_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0


### PR DESCRIPTION
## Summary

Fixes #1045.

PR #1044 made the `examples/` integration tests **fail** (rather than silently skip) when `TFE_ORGANIZATION`/`TFE_TOKEN` are missing in CI, and injected those creds into the `Run tests` step of `run-acceptance-tests.yml`. It did **not** touch the equivalent step in `build.yml`, `prerelease.yml`, or `release.yml`, so the push-triggered `build.yml` run on `master` now fails:

```
examples_test.go:44: Failing... cannot find TFE_TOKEN
```

## Changes

- Inject `TFE_ORGANIZATION`/`TFE_TOKEN` (from `steps.esc-secrets.outputs.*`) into the `Run tests` step of `build.yml`, `prerelease.yml`, and `release.yml`, mirroring `run-acceptance-tests.yml`. Each `test` job already has an `esc-secrets` step, so the outputs resolve.
- Fix a pre-existing typo in `release.yml`: `GTIHUB_TOKEN` → `GITHUB_TOKEN`.

## Durable fix

These are manual edits to autogenerated files. The root cause is in the **ci-mgmt** native templates, which hardcode each `Run tests` step's `env` (only `GITHUB_TOKEN`) instead of applying `renderLocalEnv` the way the `Test Provider Library` step does. The `GTIHUB_TOKEN` typo also originates in the ci-mgmt `release.yml` template. A follow-up should fix the templates so these survive the next regeneration.