### PR TITLE
Extract repeated string literals into constants for goconst

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -33,6 +33,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
+// stateKey is the stack output key holding the fetched Terraform state outputs.
+const stateKey = "state"
+
 func getRemoteBackendOrganization(t *testing.T) string { return getEnv(t, "TFE_ORGANIZATION") }
 
 func getRemoteBackendToken(t *testing.T) string { return getEnv(t, "TFE_TOKEN") }
@@ -168,7 +171,7 @@ func LanguageTests(t *testing.T, language string) {
 		"local": {
 			doesNotNeedConfig: true,
 			expectedStackOutputs: map[string]any{
-				"state": map[string]any{
+				stateKey: map[string]any{
 					"bucket_arn": "arn:aws:s3:::hello-world-abc12345",
 					"public_subnet_ids": []any{
 						"subnet-023a5a6867d194162",
@@ -183,7 +186,7 @@ func LanguageTests(t *testing.T, language string) {
 		},
 		"remote": {
 			expectedStackOutputs: map[string]any{
-				"state": map[string]any{
+				stateKey: map[string]any{
 					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
 					"plaintext":                        "{\"password\":\"EOZcr9x4V@ep8T1gjmR4RJ39aT9vQDsDwZx\"}",
 				},
@@ -200,7 +203,7 @@ func LanguageTests(t *testing.T, language string) {
 			//   "1b47061264138c4ac30d75fd1eb44270" = secret signature value
 			//   "plaintext" = the actual outputs serialized as a JSON string
 			expectedStackOutputs: map[string]any{
-				"state": map[string]any{
+				stateKey: map[string]any{
 					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
 					"plaintext":                        `{"test_output":"hello-from-integration-test"}`,
 				},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,6 +29,10 @@ import (
 
 const (
 	Name = "terraform"
+
+	// respectSchemaVersionKey is the per-language overlay key that opts the
+	// generated SDK into schema-version-aware packaging.
+	respectSchemaVersionKey = "respectSchemaVersion"
 )
 
 // This provider uses the `pulumi-go-provider` library to produce a code-first provider definition.
@@ -51,22 +55,22 @@ func NewProvider() p.Provider {
 			LogoURL:    "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
 			LanguageMap: map[string]any{
 				"csharp": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersionKey: true,
 					"packageReferences": map[string]string{
 						"Pulumi": "3.*",
 					},
 				},
 				"go": map[string]any{
-					"respectSchemaVersion":           true,
+					respectSchemaVersionKey:          true,
 					"generateResourceContainerTypes": true,
 					"importBasePath": fmt.Sprintf(
 						"github.com/pulumi/pulumi-terraform/sdk/v%d/go/terraform", version.Version.Major),
 				},
 				"nodejs": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersionKey: true,
 				},
 				"python": map[string]any{
-					"respectSchemaVersion": true,
+					respectSchemaVersionKey: true,
 					"pyproject": map[string]bool{
 						"enabled": true,
 					},

--- a/provider/state_reference/remote.go
+++ b/provider/state_reference/remote.go
@@ -74,7 +74,7 @@ type Workspaces struct {
 // interprets it as multi-workspace mode (which requires prefix instead).
 func (r Workspaces) stateMgrName() string {
 	if r.Name != nil {
-		return "default"
+		return defaultWorkspace
 	}
 	return stringOrZero(r.Prefix)
 }

--- a/provider/state_reference/remote_test.go
+++ b/provider/state_reference/remote_test.go
@@ -35,7 +35,7 @@ func TestWorkspacesStateMgrName(t *testing.T) {
 		{
 			name:     "name set passes default to StateMgr",
 			ws:       Workspaces{Name: ptr("my-workspace")},
-			expected: "default",
+			expected: defaultWorkspace,
 		},
 		{
 			name:     "prefix set passes prefix to StateMgr",
@@ -50,7 +50,7 @@ func TestWorkspacesStateMgrName(t *testing.T) {
 		{
 			name:     "name takes precedence over prefix",
 			ws:       Workspaces{Name: ptr("my-workspace"), Prefix: ptr("app-")},
-			expected: "default",
+			expected: defaultWorkspace,
 		},
 	}
 
@@ -65,7 +65,7 @@ func TestStateReferenceReadLocal(t *testing.T) {
 	InitTfBackend()
 
 	outputs, err := shim.StateReferenceRead(
-		context.Background(), "local", "default", map[string]cty.Value{
+		context.Background(), "local", defaultWorkspace, map[string]cty.Value{
 			"path": cty.StringVal("testdata/test.tfstate"),
 		},
 	)
@@ -79,7 +79,7 @@ func TestStateReferenceReadUnsupportedBackend(t *testing.T) {
 	InitTfBackend()
 
 	_, err := shim.StateReferenceRead(
-		context.Background(), "nonexistent", "default", map[string]cty.Value{},
+		context.Background(), "nonexistent", defaultWorkspace, map[string]cty.Value{},
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported backend type")

--- a/provider/state_reference/s3.go
+++ b/provider/state_reference/s3.go
@@ -101,7 +101,7 @@ func (r *GetS3ReferenceArgs) Annotate(a infer.Annotator) {
 	a.Describe(&r.SkipRegionValidation, "Skip static validation of region name.")
 	a.Describe(&r.SkipMetadataAPICheck, "Skip the AWS Metadata API check.")
 
-	a.SetDefault(&r.Workspace, "default")
+	a.SetDefault(&r.Workspace, defaultWorkspace)
 }
 
 // WireDependencies lets us tell users that our outputs shouldn't be secret, even when

--- a/provider/state_reference/s3_test.go
+++ b/provider/state_reference/s3_test.go
@@ -59,7 +59,7 @@ func TestStateReferenceReadS3(t *testing.T) {
 	InitTfBackend()
 	resp, err := (&GetS3Reference{}).Invoke(ctx, infer.FunctionRequest[GetS3ReferenceArgs]{
 		Input: GetS3ReferenceArgs{
-			Workspace:                 ptr("default"),
+			Workspace:                 ptr(defaultWorkspace),
 			Bucket:                    bucket,
 			Key:                       key,
 			Region:                    ptr("us-east-1"),

--- a/provider/state_reference/state_reference.go
+++ b/provider/state_reference/state_reference.go
@@ -21,6 +21,10 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
+// defaultWorkspace is the sentinel name Terraform backends use for the
+// implicit, always-present workspace.
+const defaultWorkspace = "default"
+
 func InitTfBackend() { shim.InitTfBackend() }
 
 type StateReferenceOutputs struct {


### PR DESCRIPTION
The ci-mgmt workflow update bumps golangci-lint to 2.12.2, which enables stricter `goconst` checks. This hoists repeated string literals into named constants (reusing the existing `defaultWorkspace` constant for the `state_reference` package). Verified locally with golangci-lint 2.12.2 reporting 0 issues.

Part of #1097
Part of pulumi/home#4817
