### PR TITLE
Add assume-role arguments to getS3Reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.253.0
 	github.com/pulumi/pulumi/sdk/v3 v3.253.0
 	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/minio v0.42.0
 	github.com/zclconf/go-cty v1.16.3
 )
@@ -270,7 +271,6 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.0.588 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.233 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.29 // indirect
-	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect

--- a/provider/state_reference/s3.go
+++ b/provider/state_reference/s3.go
@@ -56,6 +56,15 @@ type GetS3ReferenceArgs struct {
 	Profile               *string `pulumi:"profile,optional"`
 	SharedCredentialsFile *string `pulumi:"sharedCredentialsFile,optional"`
 
+	RoleArn                     *string           `pulumi:"roleArn,optional"`
+	SessionName                 *string           `pulumi:"sessionName,optional"`
+	ExternalID                  *string           `pulumi:"externalId,optional"`
+	AssumeRoleDurationSeconds   *int              `pulumi:"assumeRoleDurationSeconds,optional"`
+	AssumeRolePolicy            *string           `pulumi:"assumeRolePolicy,optional"`
+	AssumeRolePolicyArns        []string          `pulumi:"assumeRolePolicyArns,optional"`
+	AssumeRoleTags              map[string]string `pulumi:"assumeRoleTags,optional"`
+	AssumeRoleTransitiveTagKeys []string          `pulumi:"assumeRoleTransitiveTagKeys,optional"`
+
 	Encrypt        *bool   `pulumi:"encrypt,optional"`
 	KmsKeyID       *string `pulumi:"kmsKeyId,optional"`
 	SseCustomerKey *string `pulumi:"sseCustomerKey,optional" provider:"secret"`
@@ -88,6 +97,17 @@ func (r *GetS3ReferenceArgs) Annotate(a infer.Annotator) {
 	a.Describe(&r.Token, "AWS session token.")
 	a.Describe(&r.Profile, "AWS profile name as set in the shared credentials file.")
 	a.Describe(&r.SharedCredentialsFile, "Path to a shared credentials file.")
+
+	a.Describe(&r.RoleArn, "The ARN of an IAM Role to be assumed in order to read the state.")
+	a.Describe(&r.SessionName, "The session name to use when assuming the role.")
+	a.Describe(&r.ExternalID, "The external ID to use when assuming the role.")
+	a.Describe(&r.AssumeRoleDurationSeconds, "The duration, in seconds, of the assume role session.")
+	a.Describe(&r.AssumeRolePolicy, "IAM Policy JSON describing further restricting permissions for "+
+		"the IAM Role being assumed.")
+	a.Describe(&r.AssumeRolePolicyArns, "Amazon Resource Names (ARNs) of IAM Policies describing further "+
+		"restricting permissions for the IAM Role being assumed.")
+	a.Describe(&r.AssumeRoleTags, "Assume role session tags.")
+	a.Describe(&r.AssumeRoleTransitiveTagKeys, "Assume role session tag keys to pass to any subsequent sessions.")
 
 	a.Describe(&r.Encrypt, "Whether to enable server side encryption of the state file.")
 	a.Describe(&r.KmsKeyID, "The ARN of a KMS Key to use for encrypting the state.")
@@ -122,26 +142,34 @@ func (r *GetS3Reference) Invoke(
 	args := req.Input
 
 	results, err := shim.StateReferenceRead(ctx, "s3", *args.Workspace, map[string]cty.Value{
-		"bucket":                      cty.StringVal(args.Bucket),
-		"key":                         cty.StringVal(args.Key),
-		"region":                      ctyStringOrNil(args.Region),
-		"endpoint":                    ctyStringOrNil(args.Endpoint),
-		"sts_endpoint":                ctyStringOrNil(args.StsEndpoint),
-		"iam_endpoint":                ctyStringOrNil(args.IamEndpoint),
-		"force_path_style":            ctyBoolOrNil(args.ForcePathStyle),
-		"access_key":                  ctyStringOrNil(args.AccessKey),
-		"secret_key":                  ctyStringOrNil(args.SecretKey),
-		"token":                       ctyStringOrNil(args.Token),
-		"profile":                     ctyStringOrNil(args.Profile),
-		"shared_credentials_file":     ctyStringOrNil(args.SharedCredentialsFile),
-		"encrypt":                     ctyBoolOrNil(args.Encrypt),
-		"kms_key_id":                  ctyStringOrNil(args.KmsKeyID),
-		"sse_customer_key":            ctyStringOrNil(args.SseCustomerKey),
-		"workspace_key_prefix":        ctyStringOrNil(args.WorkspaceKeyPrefix),
-		"max_retries":                 ctyIntOrNil(args.MaxRetries),
-		"skip_credentials_validation": ctyBoolOrNil(args.SkipCredentialsValidation),
-		"skip_region_validation":      ctyBoolOrNil(args.SkipRegionValidation),
-		"skip_metadata_api_check":     ctyBoolOrNil(args.SkipMetadataAPICheck),
+		"bucket":                          cty.StringVal(args.Bucket),
+		"key":                             cty.StringVal(args.Key),
+		"region":                          ctyStringOrNil(args.Region),
+		"endpoint":                        ctyStringOrNil(args.Endpoint),
+		"sts_endpoint":                    ctyStringOrNil(args.StsEndpoint),
+		"iam_endpoint":                    ctyStringOrNil(args.IamEndpoint),
+		"force_path_style":                ctyBoolOrNil(args.ForcePathStyle),
+		"access_key":                      ctyStringOrNil(args.AccessKey),
+		"secret_key":                      ctyStringOrNil(args.SecretKey),
+		"token":                           ctyStringOrNil(args.Token),
+		"profile":                         ctyStringOrNil(args.Profile),
+		"shared_credentials_file":         ctyStringOrNil(args.SharedCredentialsFile),
+		"role_arn":                        ctyStringOrNil(args.RoleArn),
+		"session_name":                    ctyStringOrNil(args.SessionName),
+		"external_id":                     ctyStringOrNil(args.ExternalID),
+		"assume_role_duration_seconds":    ctyIntOrNil(args.AssumeRoleDurationSeconds),
+		"assume_role_policy":              ctyStringOrNil(args.AssumeRolePolicy),
+		"assume_role_policy_arns":         ctyStringSetOrNil(args.AssumeRolePolicyArns),
+		"assume_role_tags":                ctyStringMapOrNil(args.AssumeRoleTags),
+		"assume_role_transitive_tag_keys": ctyStringSetOrNil(args.AssumeRoleTransitiveTagKeys),
+		"encrypt":                         ctyBoolOrNil(args.Encrypt),
+		"kms_key_id":                      ctyStringOrNil(args.KmsKeyID),
+		"sse_customer_key":                ctyStringOrNil(args.SseCustomerKey),
+		"workspace_key_prefix":            ctyStringOrNil(args.WorkspaceKeyPrefix),
+		"max_retries":                     ctyIntOrNil(args.MaxRetries),
+		"skip_credentials_validation":     ctyBoolOrNil(args.SkipCredentialsValidation),
+		"skip_region_validation":          ctyBoolOrNil(args.SkipRegionValidation),
+		"skip_metadata_api_check":         ctyBoolOrNil(args.SkipMetadataAPICheck),
 	})
 
 	return infer.FunctionResponse[StateReferenceOutputs]{Output: StateReferenceOutputs{results}}, err

--- a/provider/state_reference/s3_test.go
+++ b/provider/state_reference/s3_test.go
@@ -17,9 +17,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
 	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
 
 	"github.com/pulumi/pulumi-go-provider/infer"
@@ -71,6 +75,7 @@ func TestStateReferenceReadS3(t *testing.T) {
 func TestStateReferenceReadS3AssumeRole(t *testing.T) {
 	ctx := t.Context()
 	endpoint := startSeededMinio(ctx, t)
+	configureAssumeRoleUser(ctx, t, endpoint)
 
 	InitTfBackend()
 	resp, err := (&GetS3Reference{}).Invoke(ctx, infer.FunctionRequest[GetS3ReferenceArgs]{
@@ -82,8 +87,8 @@ func TestStateReferenceReadS3AssumeRole(t *testing.T) {
 			Endpoint:                  ptr(endpoint),
 			StsEndpoint:               ptr(endpoint),
 			ForcePathStyle:            ptr(true),
-			AccessKey:                 ptr(username),
-			SecretKey:                 ptr(password),
+			AccessKey:                 ptr(assumeRoleUsername),
+			SecretKey:                 ptr(assumeRolePassword),
 			RoleArn:                   ptr("arn:aws:iam::123456789012:role/terraform-state-reader"),
 			SessionName:               ptr("pulumi-terraform-test"),
 			SkipCredentialsValidation: ptr(true),
@@ -104,7 +109,68 @@ const (
 	key      = "env/terraform.tfstate"
 	username = "minioadmin"
 	password = "minioadmin"
+
+	assumeRoleUsername = "assume-role-user"
+	assumeRolePassword = "assume-role-password"
 )
+
+// configureAssumeRoleUser creates a MinIO user whose policy allows reading the
+// state only with STS credentials. MinIO sets aws:principaltype to "User" for
+// static credentials and "AssumedRole" for credentials returned by AssumeRole.
+func configureAssumeRoleUser(ctx context.Context, t *testing.T, endpoint string) {
+	t.Helper()
+
+	target, err := url.Parse(endpoint)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(target.Port())
+	require.NoError(t, err)
+
+	mc, err := testcontainers.Run(ctx, "minio/mc:RELEASE.2024-11-21T17-21-54Z",
+		testcontainers.WithEntrypoint("tail", "-f", "/dev/null"),
+		testcontainers.WithHostPortAccess(port))
+	testcontainers.CleanupContainer(t, mc, testcontainers.StopTimeout(0))
+	require.NoError(t, err)
+
+	aliasEndpoint := fmt.Sprintf("http://%s:%d", testcontainers.HostInternal, port)
+	runMC := func(args ...string) {
+		t.Helper()
+		exitCode, output, err := mc.Exec(ctx, args)
+		require.NoError(t, err)
+		out, err := io.ReadAll(output)
+		require.NoError(t, err)
+		require.Equal(t, 0, exitCode, "%v failed:\n%s", args, out)
+	}
+
+	runMC("mc", "alias", "set", "test", aliasEndpoint, username, password)
+	runMC("mc", "admin", "user", "add", "test", assumeRoleUsername, assumeRolePassword)
+
+	policy := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:ListBucket"],
+    "Resource": ["arn:aws:s3:::%[1]s", "arn:aws:s3:::%[1]s/*"],
+    "Condition": {"StringEquals": {"aws:principaltype": "AssumedRole"}}
+  }]
+}`, bucket)
+	require.NoError(t, mc.CopyToContainer(ctx, []byte(policy), "/tmp/assume-role-policy.json", 0o600))
+	runMC("mc", "admin", "policy", "create", "test", "assume-role-only", "/tmp/assume-role-policy.json")
+	runMC("mc", "admin", "policy", "attach", "test", "assume-role-only", "--user", assumeRoleUsername)
+
+	// Prove that the source credentials cannot read the state directly. The
+	// GetS3Reference invocation can succeed only by using AssumeRole credentials.
+	directClient := s3.New(s3.Options{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(endpoint),
+		UsePathStyle: true,
+		Credentials:  credentials.NewStaticCredentialsProvider(assumeRoleUsername, assumeRolePassword, ""),
+	})
+	_, err = directClient.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	require.ErrorContains(t, err, "StatusCode: 403")
+}
 
 // startSeededMinio runs a MinIO container holding a Terraform state file with
 // known outputs and returns its endpoint URL.
@@ -113,6 +179,7 @@ func startSeededMinio(ctx context.Context, t *testing.T) string {
 
 	container, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-12-18T13-15-44Z",
 		tcminio.WithUsername(username), tcminio.WithPassword(password))
+	testcontainers.CleanupContainer(t, container, testcontainers.StopTimeout(0))
 	require.NoError(t, err)
 
 	hostPort, err := container.ConnectionString(ctx)

--- a/provider/state_reference/s3_test.go
+++ b/provider/state_reference/s3_test.go
@@ -39,22 +39,7 @@ import (
 // that state back through GetS3Reference and confirm the outputs round-trip.
 func TestStateReferenceReadS3(t *testing.T) {
 	ctx := t.Context()
-	const (
-		bucket   = "pulumi-terraform-test"
-		key      = "env/terraform.tfstate"
-		username = "minioadmin"
-		password = "minioadmin"
-	)
-
-	container, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-12-18T13-15-44Z",
-		tcminio.WithUsername(username), tcminio.WithPassword(password))
-	require.NoError(t, err)
-
-	hostPort, err := container.ConnectionString(ctx)
-	require.NoError(t, err)
-	endpoint := "http://" + hostPort
-
-	seedS3State(ctx, t, endpoint, bucket, key, username, password)
+	endpoint := startSeededMinio(ctx, t)
 
 	InitTfBackend()
 	resp, err := (&GetS3Reference{}).Invoke(ctx, infer.FunctionRequest[GetS3ReferenceArgs]{
@@ -78,6 +63,64 @@ func TestStateReferenceReadS3(t *testing.T) {
 		"greeting": "hello",
 		"number":   float64(42),
 	}, resp.Output.Outputs)
+}
+
+// TestStateReferenceReadS3AssumeRole reads state while authenticating through an
+// assumed role: role_arn makes the backend call STS AssumeRole (against MinIO's
+// STS API) and read the state with the returned temporary credentials.
+func TestStateReferenceReadS3AssumeRole(t *testing.T) {
+	ctx := t.Context()
+	endpoint := startSeededMinio(ctx, t)
+
+	InitTfBackend()
+	resp, err := (&GetS3Reference{}).Invoke(ctx, infer.FunctionRequest[GetS3ReferenceArgs]{
+		Input: GetS3ReferenceArgs{
+			Workspace:                 ptr(defaultWorkspace),
+			Bucket:                    bucket,
+			Key:                       key,
+			Region:                    ptr("us-east-1"),
+			Endpoint:                  ptr(endpoint),
+			StsEndpoint:               ptr(endpoint),
+			ForcePathStyle:            ptr(true),
+			AccessKey:                 ptr(username),
+			SecretKey:                 ptr(password),
+			RoleArn:                   ptr("arn:aws:iam::123456789012:role/terraform-state-reader"),
+			SessionName:               ptr("pulumi-terraform-test"),
+			SkipCredentialsValidation: ptr(true),
+			SkipRegionValidation:      ptr(true),
+			SkipMetadataAPICheck:      ptr(true),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"greeting": "hello",
+		"number":   float64(42),
+	}, resp.Output.Outputs)
+}
+
+const (
+	bucket   = "pulumi-terraform-test"
+	key      = "env/terraform.tfstate"
+	username = "minioadmin"
+	password = "minioadmin"
+)
+
+// startSeededMinio runs a MinIO container holding a Terraform state file with
+// known outputs and returns its endpoint URL.
+func startSeededMinio(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	container, err := tcminio.Run(ctx, "minio/minio:RELEASE.2024-12-18T13-15-44Z",
+		tcminio.WithUsername(username), tcminio.WithPassword(password))
+	require.NoError(t, err)
+
+	hostPort, err := container.ConnectionString(ctx)
+	require.NoError(t, err)
+	endpoint := "http://" + hostPort
+
+	seedS3State(ctx, t, endpoint, bucket, key, username, password)
+	return endpoint
 }
 
 // seedS3State creates the state bucket and runs tofu apply against it so the

--- a/provider/state_reference/s3_test.go
+++ b/provider/state_reference/s3_test.go
@@ -64,7 +64,7 @@ func TestStateReferenceReadS3(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]any{
-		"greeting": "hello",
+		"greeting": greeting,
 		"number":   float64(42),
 	}, resp.Output.Outputs)
 }
@@ -99,7 +99,7 @@ func TestStateReferenceReadS3AssumeRole(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]any{
-		"greeting": "hello",
+		"greeting": greeting,
 		"number":   float64(42),
 	}, resp.Output.Outputs)
 }
@@ -112,6 +112,8 @@ const (
 
 	assumeRoleUsername = "assume-role-user"
 	assumeRolePassword = "assume-role-password"
+
+	greeting = "hello"
 )
 
 // configureAssumeRoleUser creates a MinIO user whose policy allows reading the

--- a/provider/state_reference/state_reference.go
+++ b/provider/state_reference/state_reference.go
@@ -62,6 +62,28 @@ func ctyIntOrNil(v *int) cty.Value {
 	return cty.NumberIntVal(int64(*v))
 }
 
+func ctyStringSetOrNil(v []string) cty.Value {
+	if len(v) == 0 {
+		return cty.NullVal(cty.Set(cty.String))
+	}
+	elems := make([]cty.Value, len(v))
+	for i, s := range v {
+		elems[i] = cty.StringVal(s)
+	}
+	return cty.SetVal(elems)
+}
+
+func ctyStringMapOrNil(v map[string]string) cty.Value {
+	if len(v) == 0 {
+		return cty.NullVal(cty.Map(cty.String))
+	}
+	elems := make(map[string]cty.Value, len(v))
+	for k, s := range v {
+		elems[k] = cty.StringVal(s)
+	}
+	return cty.MapVal(elems)
+}
+
 func stringOrZero(v *string) string {
 	if v == nil {
 		return ""

--- a/schema.json
+++ b/schema.json
@@ -146,6 +146,35 @@
             "description": "AWS access key.",
             "secret": true
           },
+          "assumeRoleDurationSeconds": {
+            "type": "integer",
+            "description": "The duration, in seconds, of the assume role session."
+          },
+          "assumeRolePolicy": {
+            "type": "string",
+            "description": "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed."
+          },
+          "assumeRolePolicyArns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed."
+          },
+          "assumeRoleTags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Assume role session tags."
+          },
+          "assumeRoleTransitiveTagKeys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Assume role session tag keys to pass to any subsequent sessions."
+          },
           "bucket": {
             "type": "string",
             "description": "The name of the S3 bucket."
@@ -157,6 +186,10 @@
           "endpoint": {
             "type": "string",
             "description": "A custom endpoint for the S3 API."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The external ID to use when assuming the role."
           },
           "forcePathStyle": {
             "type": "boolean",
@@ -186,10 +219,18 @@
             "type": "string",
             "description": "AWS region of the S3 bucket. Falls back to the AWS_REGION or AWS_DEFAULT_REGION environment variables when unset."
           },
+          "roleArn": {
+            "type": "string",
+            "description": "The ARN of an IAM Role to be assumed in order to read the state."
+          },
           "secretKey": {
             "type": "string",
             "description": "AWS secret key.",
             "secret": true
+          },
+          "sessionName": {
+            "type": "string",
+            "description": "The session name to use when assuming the role."
           },
           "sharedCredentialsFile": {
             "type": "string",

--- a/sdk/dotnet/State/GetS3Reference.cs
+++ b/sdk/dotnet/State/GetS3Reference.cs
@@ -46,6 +46,54 @@ namespace Pulumi.Terraform.State
         }
 
         /// <summary>
+        /// The duration, in seconds, of the assume role session.
+        /// </summary>
+        [Input("assumeRoleDurationSeconds")]
+        public int? AssumeRoleDurationSeconds { get; set; }
+
+        /// <summary>
+        /// IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+        /// </summary>
+        [Input("assumeRolePolicy")]
+        public string? AssumeRolePolicy { get; set; }
+
+        [Input("assumeRolePolicyArns")]
+        private List<string>? _assumeRolePolicyArns;
+
+        /// <summary>
+        /// Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+        /// </summary>
+        public List<string> AssumeRolePolicyArns
+        {
+            get => _assumeRolePolicyArns ?? (_assumeRolePolicyArns = new List<string>());
+            set => _assumeRolePolicyArns = value;
+        }
+
+        [Input("assumeRoleTags")]
+        private Dictionary<string, string>? _assumeRoleTags;
+
+        /// <summary>
+        /// Assume role session tags.
+        /// </summary>
+        public Dictionary<string, string> AssumeRoleTags
+        {
+            get => _assumeRoleTags ?? (_assumeRoleTags = new Dictionary<string, string>());
+            set => _assumeRoleTags = value;
+        }
+
+        [Input("assumeRoleTransitiveTagKeys")]
+        private List<string>? _assumeRoleTransitiveTagKeys;
+
+        /// <summary>
+        /// Assume role session tag keys to pass to any subsequent sessions.
+        /// </summary>
+        public List<string> AssumeRoleTransitiveTagKeys
+        {
+            get => _assumeRoleTransitiveTagKeys ?? (_assumeRoleTransitiveTagKeys = new List<string>());
+            set => _assumeRoleTransitiveTagKeys = value;
+        }
+
+        /// <summary>
         /// The name of the S3 bucket.
         /// </summary>
         [Input("bucket", required: true)]
@@ -62,6 +110,12 @@ namespace Pulumi.Terraform.State
         /// </summary>
         [Input("endpoint")]
         public string? Endpoint { get; set; }
+
+        /// <summary>
+        /// The external ID to use when assuming the role.
+        /// </summary>
+        [Input("externalId")]
+        public string? ExternalId { get; set; }
 
         /// <summary>
         /// Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
@@ -105,6 +159,12 @@ namespace Pulumi.Terraform.State
         [Input("region")]
         public string? Region { get; set; }
 
+        /// <summary>
+        /// The ARN of an IAM Role to be assumed in order to read the state.
+        /// </summary>
+        [Input("roleArn")]
+        public string? RoleArn { get; set; }
+
         [Input("secretKey")]
         private string? _secretKey;
 
@@ -116,6 +176,12 @@ namespace Pulumi.Terraform.State
             get => _secretKey;
             set => _secretKey = value;
         }
+
+        /// <summary>
+        /// The session name to use when assuming the role.
+        /// </summary>
+        [Input("sessionName")]
+        public string? SessionName { get; set; }
 
         /// <summary>
         /// Path to a shared credentials file.
@@ -209,6 +275,54 @@ namespace Pulumi.Terraform.State
         }
 
         /// <summary>
+        /// The duration, in seconds, of the assume role session.
+        /// </summary>
+        [Input("assumeRoleDurationSeconds")]
+        public Input<int>? AssumeRoleDurationSeconds { get; set; }
+
+        /// <summary>
+        /// IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+        /// </summary>
+        [Input("assumeRolePolicy")]
+        public Input<string>? AssumeRolePolicy { get; set; }
+
+        [Input("assumeRolePolicyArns")]
+        private InputList<string>? _assumeRolePolicyArns;
+
+        /// <summary>
+        /// Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+        /// </summary>
+        public InputList<string> AssumeRolePolicyArns
+        {
+            get => _assumeRolePolicyArns ?? (_assumeRolePolicyArns = new InputList<string>());
+            set => _assumeRolePolicyArns = value;
+        }
+
+        [Input("assumeRoleTags")]
+        private InputMap<string>? _assumeRoleTags;
+
+        /// <summary>
+        /// Assume role session tags.
+        /// </summary>
+        public InputMap<string> AssumeRoleTags
+        {
+            get => _assumeRoleTags ?? (_assumeRoleTags = new InputMap<string>());
+            set => _assumeRoleTags = value;
+        }
+
+        [Input("assumeRoleTransitiveTagKeys")]
+        private InputList<string>? _assumeRoleTransitiveTagKeys;
+
+        /// <summary>
+        /// Assume role session tag keys to pass to any subsequent sessions.
+        /// </summary>
+        public InputList<string> AssumeRoleTransitiveTagKeys
+        {
+            get => _assumeRoleTransitiveTagKeys ?? (_assumeRoleTransitiveTagKeys = new InputList<string>());
+            set => _assumeRoleTransitiveTagKeys = value;
+        }
+
+        /// <summary>
         /// The name of the S3 bucket.
         /// </summary>
         [Input("bucket", required: true)]
@@ -225,6 +339,12 @@ namespace Pulumi.Terraform.State
         /// </summary>
         [Input("endpoint")]
         public Input<string>? Endpoint { get; set; }
+
+        /// <summary>
+        /// The external ID to use when assuming the role.
+        /// </summary>
+        [Input("externalId")]
+        public Input<string>? ExternalId { get; set; }
 
         /// <summary>
         /// Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
@@ -268,6 +388,12 @@ namespace Pulumi.Terraform.State
         [Input("region")]
         public Input<string>? Region { get; set; }
 
+        /// <summary>
+        /// The ARN of an IAM Role to be assumed in order to read the state.
+        /// </summary>
+        [Input("roleArn")]
+        public Input<string>? RoleArn { get; set; }
+
         [Input("secretKey")]
         private Input<string>? _secretKey;
 
@@ -283,6 +409,12 @@ namespace Pulumi.Terraform.State
                 _secretKey = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
+
+        /// <summary>
+        /// The session name to use when assuming the role.
+        /// </summary>
+        [Input("sessionName")]
+        public Input<string>? SessionName { get; set; }
 
         /// <summary>
         /// Path to a shared credentials file.

--- a/sdk/go/terraform/state/getS3Reference.go
+++ b/sdk/go/terraform/state/getS3Reference.go
@@ -25,12 +25,24 @@ func GetS3Reference(ctx *pulumi.Context, args *GetS3ReferenceArgs, opts ...pulum
 type GetS3ReferenceArgs struct {
 	// AWS access key.
 	AccessKey *string `pulumi:"accessKey"`
+	// The duration, in seconds, of the assume role session.
+	AssumeRoleDurationSeconds *int `pulumi:"assumeRoleDurationSeconds"`
+	// IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+	AssumeRolePolicy *string `pulumi:"assumeRolePolicy"`
+	// Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+	AssumeRolePolicyArns []string `pulumi:"assumeRolePolicyArns"`
+	// Assume role session tags.
+	AssumeRoleTags map[string]string `pulumi:"assumeRoleTags"`
+	// Assume role session tag keys to pass to any subsequent sessions.
+	AssumeRoleTransitiveTagKeys []string `pulumi:"assumeRoleTransitiveTagKeys"`
 	// The name of the S3 bucket.
 	Bucket string `pulumi:"bucket"`
 	// Whether to enable server side encryption of the state file.
 	Encrypt *bool `pulumi:"encrypt"`
 	// A custom endpoint for the S3 API.
 	Endpoint *string `pulumi:"endpoint"`
+	// The external ID to use when assuming the role.
+	ExternalId *string `pulumi:"externalId"`
 	// Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
 	ForcePathStyle *bool `pulumi:"forcePathStyle"`
 	// A custom endpoint for the IAM API.
@@ -45,8 +57,12 @@ type GetS3ReferenceArgs struct {
 	Profile *string `pulumi:"profile"`
 	// AWS region of the S3 bucket. Falls back to the AWS_REGION or AWS_DEFAULT_REGION environment variables when unset.
 	Region *string `pulumi:"region"`
+	// The ARN of an IAM Role to be assumed in order to read the state.
+	RoleArn *string `pulumi:"roleArn"`
 	// AWS secret key.
 	SecretKey *string `pulumi:"secretKey"`
+	// The session name to use when assuming the role.
+	SessionName *string `pulumi:"sessionName"`
 	// Path to a shared credentials file.
 	SharedCredentialsFile *string `pulumi:"sharedCredentialsFile"`
 	// Skip the credentials validation via the STS API.
@@ -98,12 +114,24 @@ func GetS3ReferenceOutput(ctx *pulumi.Context, args GetS3ReferenceOutputArgs, op
 type GetS3ReferenceOutputArgs struct {
 	// AWS access key.
 	AccessKey pulumi.StringPtrInput `pulumi:"accessKey"`
+	// The duration, in seconds, of the assume role session.
+	AssumeRoleDurationSeconds pulumi.IntPtrInput `pulumi:"assumeRoleDurationSeconds"`
+	// IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+	AssumeRolePolicy pulumi.StringPtrInput `pulumi:"assumeRolePolicy"`
+	// Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+	AssumeRolePolicyArns pulumi.StringArrayInput `pulumi:"assumeRolePolicyArns"`
+	// Assume role session tags.
+	AssumeRoleTags pulumi.StringMapInput `pulumi:"assumeRoleTags"`
+	// Assume role session tag keys to pass to any subsequent sessions.
+	AssumeRoleTransitiveTagKeys pulumi.StringArrayInput `pulumi:"assumeRoleTransitiveTagKeys"`
 	// The name of the S3 bucket.
 	Bucket pulumi.StringInput `pulumi:"bucket"`
 	// Whether to enable server side encryption of the state file.
 	Encrypt pulumi.BoolPtrInput `pulumi:"encrypt"`
 	// A custom endpoint for the S3 API.
 	Endpoint pulumi.StringPtrInput `pulumi:"endpoint"`
+	// The external ID to use when assuming the role.
+	ExternalId pulumi.StringPtrInput `pulumi:"externalId"`
 	// Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
 	ForcePathStyle pulumi.BoolPtrInput `pulumi:"forcePathStyle"`
 	// A custom endpoint for the IAM API.
@@ -118,8 +146,12 @@ type GetS3ReferenceOutputArgs struct {
 	Profile pulumi.StringPtrInput `pulumi:"profile"`
 	// AWS region of the S3 bucket. Falls back to the AWS_REGION or AWS_DEFAULT_REGION environment variables when unset.
 	Region pulumi.StringPtrInput `pulumi:"region"`
+	// The ARN of an IAM Role to be assumed in order to read the state.
+	RoleArn pulumi.StringPtrInput `pulumi:"roleArn"`
 	// AWS secret key.
 	SecretKey pulumi.StringPtrInput `pulumi:"secretKey"`
+	// The session name to use when assuming the role.
+	SessionName pulumi.StringPtrInput `pulumi:"sessionName"`
 	// Path to a shared credentials file.
 	SharedCredentialsFile pulumi.StringPtrInput `pulumi:"sharedCredentialsFile"`
 	// Skip the credentials validation via the STS API.

--- a/sdk/java/src/main/java/com/pulumi/terraform/state/inputs/GetS3ReferenceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/terraform/state/inputs/GetS3ReferenceArgs.java
@@ -10,6 +10,8 @@ import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -32,6 +34,81 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
      */
     public Optional<Output<String>> accessKey() {
         return Optional.ofNullable(this.accessKey);
+    }
+
+    /**
+     * The duration, in seconds, of the assume role session.
+     * 
+     */
+    @Import(name="assumeRoleDurationSeconds")
+    private @Nullable Output<Integer> assumeRoleDurationSeconds;
+
+    /**
+     * @return The duration, in seconds, of the assume role session.
+     * 
+     */
+    public Optional<Output<Integer>> assumeRoleDurationSeconds() {
+        return Optional.ofNullable(this.assumeRoleDurationSeconds);
+    }
+
+    /**
+     * IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    @Import(name="assumeRolePolicy")
+    private @Nullable Output<String> assumeRolePolicy;
+
+    /**
+     * @return IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    public Optional<Output<String>> assumeRolePolicy() {
+        return Optional.ofNullable(this.assumeRolePolicy);
+    }
+
+    /**
+     * Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    @Import(name="assumeRolePolicyArns")
+    private @Nullable Output<List<String>> assumeRolePolicyArns;
+
+    /**
+     * @return Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    public Optional<Output<List<String>>> assumeRolePolicyArns() {
+        return Optional.ofNullable(this.assumeRolePolicyArns);
+    }
+
+    /**
+     * Assume role session tags.
+     * 
+     */
+    @Import(name="assumeRoleTags")
+    private @Nullable Output<Map<String,String>> assumeRoleTags;
+
+    /**
+     * @return Assume role session tags.
+     * 
+     */
+    public Optional<Output<Map<String,String>>> assumeRoleTags() {
+        return Optional.ofNullable(this.assumeRoleTags);
+    }
+
+    /**
+     * Assume role session tag keys to pass to any subsequent sessions.
+     * 
+     */
+    @Import(name="assumeRoleTransitiveTagKeys")
+    private @Nullable Output<List<String>> assumeRoleTransitiveTagKeys;
+
+    /**
+     * @return Assume role session tag keys to pass to any subsequent sessions.
+     * 
+     */
+    public Optional<Output<List<String>>> assumeRoleTransitiveTagKeys() {
+        return Optional.ofNullable(this.assumeRoleTransitiveTagKeys);
     }
 
     /**
@@ -77,6 +154,21 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
      */
     public Optional<Output<String>> endpoint() {
         return Optional.ofNullable(this.endpoint);
+    }
+
+    /**
+     * The external ID to use when assuming the role.
+     * 
+     */
+    @Import(name="externalId")
+    private @Nullable Output<String> externalId;
+
+    /**
+     * @return The external ID to use when assuming the role.
+     * 
+     */
+    public Optional<Output<String>> externalId() {
+        return Optional.ofNullable(this.externalId);
     }
 
     /**
@@ -185,6 +277,21 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
     }
 
     /**
+     * The ARN of an IAM Role to be assumed in order to read the state.
+     * 
+     */
+    @Import(name="roleArn")
+    private @Nullable Output<String> roleArn;
+
+    /**
+     * @return The ARN of an IAM Role to be assumed in order to read the state.
+     * 
+     */
+    public Optional<Output<String>> roleArn() {
+        return Optional.ofNullable(this.roleArn);
+    }
+
+    /**
      * AWS secret key.
      * 
      */
@@ -197,6 +304,21 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
      */
     public Optional<Output<String>> secretKey() {
         return Optional.ofNullable(this.secretKey);
+    }
+
+    /**
+     * The session name to use when assuming the role.
+     * 
+     */
+    @Import(name="sessionName")
+    private @Nullable Output<String> sessionName;
+
+    /**
+     * @return The session name to use when assuming the role.
+     * 
+     */
+    public Optional<Output<String>> sessionName() {
+        return Optional.ofNullable(this.sessionName);
     }
 
     /**
@@ -338,9 +460,15 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
 
     private GetS3ReferenceArgs(GetS3ReferenceArgs $) {
         this.accessKey = $.accessKey;
+        this.assumeRoleDurationSeconds = $.assumeRoleDurationSeconds;
+        this.assumeRolePolicy = $.assumeRolePolicy;
+        this.assumeRolePolicyArns = $.assumeRolePolicyArns;
+        this.assumeRoleTags = $.assumeRoleTags;
+        this.assumeRoleTransitiveTagKeys = $.assumeRoleTransitiveTagKeys;
         this.bucket = $.bucket;
         this.encrypt = $.encrypt;
         this.endpoint = $.endpoint;
+        this.externalId = $.externalId;
         this.forcePathStyle = $.forcePathStyle;
         this.iamEndpoint = $.iamEndpoint;
         this.key = $.key;
@@ -348,7 +476,9 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
         this.maxRetries = $.maxRetries;
         this.profile = $.profile;
         this.region = $.region;
+        this.roleArn = $.roleArn;
         this.secretKey = $.secretKey;
+        this.sessionName = $.sessionName;
         this.sharedCredentialsFile = $.sharedCredentialsFile;
         this.skipCredentialsValidation = $.skipCredentialsValidation;
         this.skipMetadataApiCheck = $.skipMetadataApiCheck;
@@ -397,6 +527,131 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
          */
         public Builder accessKey(String accessKey) {
             return accessKey(Output.of(accessKey));
+        }
+
+        /**
+         * @param assumeRoleDurationSeconds The duration, in seconds, of the assume role session.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleDurationSeconds(@Nullable Output<Integer> assumeRoleDurationSeconds) {
+            $.assumeRoleDurationSeconds = assumeRoleDurationSeconds;
+            return this;
+        }
+
+        /**
+         * @param assumeRoleDurationSeconds The duration, in seconds, of the assume role session.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleDurationSeconds(Integer assumeRoleDurationSeconds) {
+            return assumeRoleDurationSeconds(Output.of(assumeRoleDurationSeconds));
+        }
+
+        /**
+         * @param assumeRolePolicy IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicy(@Nullable Output<String> assumeRolePolicy) {
+            $.assumeRolePolicy = assumeRolePolicy;
+            return this;
+        }
+
+        /**
+         * @param assumeRolePolicy IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicy(String assumeRolePolicy) {
+            return assumeRolePolicy(Output.of(assumeRolePolicy));
+        }
+
+        /**
+         * @param assumeRolePolicyArns Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicyArns(@Nullable Output<List<String>> assumeRolePolicyArns) {
+            $.assumeRolePolicyArns = assumeRolePolicyArns;
+            return this;
+        }
+
+        /**
+         * @param assumeRolePolicyArns Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicyArns(List<String> assumeRolePolicyArns) {
+            return assumeRolePolicyArns(Output.of(assumeRolePolicyArns));
+        }
+
+        /**
+         * @param assumeRolePolicyArns Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicyArns(String... assumeRolePolicyArns) {
+            return assumeRolePolicyArns(List.of(assumeRolePolicyArns));
+        }
+
+        /**
+         * @param assumeRoleTags Assume role session tags.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTags(@Nullable Output<Map<String,String>> assumeRoleTags) {
+            $.assumeRoleTags = assumeRoleTags;
+            return this;
+        }
+
+        /**
+         * @param assumeRoleTags Assume role session tags.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTags(Map<String,String> assumeRoleTags) {
+            return assumeRoleTags(Output.of(assumeRoleTags));
+        }
+
+        /**
+         * @param assumeRoleTransitiveTagKeys Assume role session tag keys to pass to any subsequent sessions.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTransitiveTagKeys(@Nullable Output<List<String>> assumeRoleTransitiveTagKeys) {
+            $.assumeRoleTransitiveTagKeys = assumeRoleTransitiveTagKeys;
+            return this;
+        }
+
+        /**
+         * @param assumeRoleTransitiveTagKeys Assume role session tag keys to pass to any subsequent sessions.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTransitiveTagKeys(List<String> assumeRoleTransitiveTagKeys) {
+            return assumeRoleTransitiveTagKeys(Output.of(assumeRoleTransitiveTagKeys));
+        }
+
+        /**
+         * @param assumeRoleTransitiveTagKeys Assume role session tag keys to pass to any subsequent sessions.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTransitiveTagKeys(String... assumeRoleTransitiveTagKeys) {
+            return assumeRoleTransitiveTagKeys(List.of(assumeRoleTransitiveTagKeys));
         }
 
         /**
@@ -460,6 +715,27 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
          */
         public Builder endpoint(String endpoint) {
             return endpoint(Output.of(endpoint));
+        }
+
+        /**
+         * @param externalId The external ID to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder externalId(@Nullable Output<String> externalId) {
+            $.externalId = externalId;
+            return this;
+        }
+
+        /**
+         * @param externalId The external ID to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder externalId(String externalId) {
+            return externalId(Output.of(externalId));
         }
 
         /**
@@ -610,6 +886,27 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
         }
 
         /**
+         * @param roleArn The ARN of an IAM Role to be assumed in order to read the state.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder roleArn(@Nullable Output<String> roleArn) {
+            $.roleArn = roleArn;
+            return this;
+        }
+
+        /**
+         * @param roleArn The ARN of an IAM Role to be assumed in order to read the state.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder roleArn(String roleArn) {
+            return roleArn(Output.of(roleArn));
+        }
+
+        /**
          * @param secretKey AWS secret key.
          * 
          * @return builder
@@ -628,6 +925,27 @@ public final class GetS3ReferenceArgs extends com.pulumi.resources.InvokeArgs {
          */
         public Builder secretKey(String secretKey) {
             return secretKey(Output.of(secretKey));
+        }
+
+        /**
+         * @param sessionName The session name to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder sessionName(@Nullable Output<String> sessionName) {
+            $.sessionName = sessionName;
+            return this;
+        }
+
+        /**
+         * @param sessionName The session name to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder sessionName(String sessionName) {
+            return sessionName(Output.of(sessionName));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/terraform/state/inputs/GetS3ReferencePlainArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/terraform/state/inputs/GetS3ReferencePlainArgs.java
@@ -9,6 +9,8 @@ import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -31,6 +33,81 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
      */
     public Optional<String> accessKey() {
         return Optional.ofNullable(this.accessKey);
+    }
+
+    /**
+     * The duration, in seconds, of the assume role session.
+     * 
+     */
+    @Import(name="assumeRoleDurationSeconds")
+    private @Nullable Integer assumeRoleDurationSeconds;
+
+    /**
+     * @return The duration, in seconds, of the assume role session.
+     * 
+     */
+    public Optional<Integer> assumeRoleDurationSeconds() {
+        return Optional.ofNullable(this.assumeRoleDurationSeconds);
+    }
+
+    /**
+     * IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    @Import(name="assumeRolePolicy")
+    private @Nullable String assumeRolePolicy;
+
+    /**
+     * @return IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    public Optional<String> assumeRolePolicy() {
+        return Optional.ofNullable(this.assumeRolePolicy);
+    }
+
+    /**
+     * Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    @Import(name="assumeRolePolicyArns")
+    private @Nullable List<String> assumeRolePolicyArns;
+
+    /**
+     * @return Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     * 
+     */
+    public Optional<List<String>> assumeRolePolicyArns() {
+        return Optional.ofNullable(this.assumeRolePolicyArns);
+    }
+
+    /**
+     * Assume role session tags.
+     * 
+     */
+    @Import(name="assumeRoleTags")
+    private @Nullable Map<String,String> assumeRoleTags;
+
+    /**
+     * @return Assume role session tags.
+     * 
+     */
+    public Optional<Map<String,String>> assumeRoleTags() {
+        return Optional.ofNullable(this.assumeRoleTags);
+    }
+
+    /**
+     * Assume role session tag keys to pass to any subsequent sessions.
+     * 
+     */
+    @Import(name="assumeRoleTransitiveTagKeys")
+    private @Nullable List<String> assumeRoleTransitiveTagKeys;
+
+    /**
+     * @return Assume role session tag keys to pass to any subsequent sessions.
+     * 
+     */
+    public Optional<List<String>> assumeRoleTransitiveTagKeys() {
+        return Optional.ofNullable(this.assumeRoleTransitiveTagKeys);
     }
 
     /**
@@ -76,6 +153,21 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
      */
     public Optional<String> endpoint() {
         return Optional.ofNullable(this.endpoint);
+    }
+
+    /**
+     * The external ID to use when assuming the role.
+     * 
+     */
+    @Import(name="externalId")
+    private @Nullable String externalId;
+
+    /**
+     * @return The external ID to use when assuming the role.
+     * 
+     */
+    public Optional<String> externalId() {
+        return Optional.ofNullable(this.externalId);
     }
 
     /**
@@ -184,6 +276,21 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
     }
 
     /**
+     * The ARN of an IAM Role to be assumed in order to read the state.
+     * 
+     */
+    @Import(name="roleArn")
+    private @Nullable String roleArn;
+
+    /**
+     * @return The ARN of an IAM Role to be assumed in order to read the state.
+     * 
+     */
+    public Optional<String> roleArn() {
+        return Optional.ofNullable(this.roleArn);
+    }
+
+    /**
      * AWS secret key.
      * 
      */
@@ -196,6 +303,21 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
      */
     public Optional<String> secretKey() {
         return Optional.ofNullable(this.secretKey);
+    }
+
+    /**
+     * The session name to use when assuming the role.
+     * 
+     */
+    @Import(name="sessionName")
+    private @Nullable String sessionName;
+
+    /**
+     * @return The session name to use when assuming the role.
+     * 
+     */
+    public Optional<String> sessionName() {
+        return Optional.ofNullable(this.sessionName);
     }
 
     /**
@@ -337,9 +459,15 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
 
     private GetS3ReferencePlainArgs(GetS3ReferencePlainArgs $) {
         this.accessKey = $.accessKey;
+        this.assumeRoleDurationSeconds = $.assumeRoleDurationSeconds;
+        this.assumeRolePolicy = $.assumeRolePolicy;
+        this.assumeRolePolicyArns = $.assumeRolePolicyArns;
+        this.assumeRoleTags = $.assumeRoleTags;
+        this.assumeRoleTransitiveTagKeys = $.assumeRoleTransitiveTagKeys;
         this.bucket = $.bucket;
         this.encrypt = $.encrypt;
         this.endpoint = $.endpoint;
+        this.externalId = $.externalId;
         this.forcePathStyle = $.forcePathStyle;
         this.iamEndpoint = $.iamEndpoint;
         this.key = $.key;
@@ -347,7 +475,9 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
         this.maxRetries = $.maxRetries;
         this.profile = $.profile;
         this.region = $.region;
+        this.roleArn = $.roleArn;
         this.secretKey = $.secretKey;
+        this.sessionName = $.sessionName;
         this.sharedCredentialsFile = $.sharedCredentialsFile;
         this.skipCredentialsValidation = $.skipCredentialsValidation;
         this.skipMetadataApiCheck = $.skipMetadataApiCheck;
@@ -389,6 +519,81 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
         }
 
         /**
+         * @param assumeRoleDurationSeconds The duration, in seconds, of the assume role session.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleDurationSeconds(@Nullable Integer assumeRoleDurationSeconds) {
+            $.assumeRoleDurationSeconds = assumeRoleDurationSeconds;
+            return this;
+        }
+
+        /**
+         * @param assumeRolePolicy IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicy(@Nullable String assumeRolePolicy) {
+            $.assumeRolePolicy = assumeRolePolicy;
+            return this;
+        }
+
+        /**
+         * @param assumeRolePolicyArns Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicyArns(@Nullable List<String> assumeRolePolicyArns) {
+            $.assumeRolePolicyArns = assumeRolePolicyArns;
+            return this;
+        }
+
+        /**
+         * @param assumeRolePolicyArns Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRolePolicyArns(String... assumeRolePolicyArns) {
+            return assumeRolePolicyArns(List.of(assumeRolePolicyArns));
+        }
+
+        /**
+         * @param assumeRoleTags Assume role session tags.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTags(@Nullable Map<String,String> assumeRoleTags) {
+            $.assumeRoleTags = assumeRoleTags;
+            return this;
+        }
+
+        /**
+         * @param assumeRoleTransitiveTagKeys Assume role session tag keys to pass to any subsequent sessions.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTransitiveTagKeys(@Nullable List<String> assumeRoleTransitiveTagKeys) {
+            $.assumeRoleTransitiveTagKeys = assumeRoleTransitiveTagKeys;
+            return this;
+        }
+
+        /**
+         * @param assumeRoleTransitiveTagKeys Assume role session tag keys to pass to any subsequent sessions.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder assumeRoleTransitiveTagKeys(String... assumeRoleTransitiveTagKeys) {
+            return assumeRoleTransitiveTagKeys(List.of(assumeRoleTransitiveTagKeys));
+        }
+
+        /**
          * @param bucket The name of the S3 bucket.
          * 
          * @return builder
@@ -418,6 +623,17 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
          */
         public Builder endpoint(@Nullable String endpoint) {
             $.endpoint = endpoint;
+            return this;
+        }
+
+        /**
+         * @param externalId The external ID to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder externalId(@Nullable String externalId) {
+            $.externalId = externalId;
             return this;
         }
 
@@ -499,6 +715,17 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
         }
 
         /**
+         * @param roleArn The ARN of an IAM Role to be assumed in order to read the state.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder roleArn(@Nullable String roleArn) {
+            $.roleArn = roleArn;
+            return this;
+        }
+
+        /**
          * @param secretKey AWS secret key.
          * 
          * @return builder
@@ -506,6 +733,17 @@ public final class GetS3ReferencePlainArgs extends com.pulumi.resources.InvokeAr
          */
         public Builder secretKey(@Nullable String secretKey) {
             $.secretKey = secretKey;
+            return this;
+        }
+
+        /**
+         * @param sessionName The session name to use when assuming the role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder sessionName(@Nullable String sessionName) {
+            $.sessionName = sessionName;
             return this;
         }
 

--- a/sdk/nodejs/state/getS3Reference.ts
+++ b/sdk/nodejs/state/getS3Reference.ts
@@ -11,9 +11,15 @@ export function getS3Reference(args: GetS3ReferenceArgs, opts?: pulumi.InvokeOpt
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("terraform:state:getS3Reference", {
         "accessKey": args.accessKey,
+        "assumeRoleDurationSeconds": args.assumeRoleDurationSeconds,
+        "assumeRolePolicy": args.assumeRolePolicy,
+        "assumeRolePolicyArns": args.assumeRolePolicyArns,
+        "assumeRoleTags": args.assumeRoleTags,
+        "assumeRoleTransitiveTagKeys": args.assumeRoleTransitiveTagKeys,
         "bucket": args.bucket,
         "encrypt": args.encrypt,
         "endpoint": args.endpoint,
+        "externalId": args.externalId,
         "forcePathStyle": args.forcePathStyle,
         "iamEndpoint": args.iamEndpoint,
         "key": args.key,
@@ -21,7 +27,9 @@ export function getS3Reference(args: GetS3ReferenceArgs, opts?: pulumi.InvokeOpt
         "maxRetries": args.maxRetries,
         "profile": args.profile,
         "region": args.region,
+        "roleArn": args.roleArn,
         "secretKey": args.secretKey,
+        "sessionName": args.sessionName,
         "sharedCredentialsFile": args.sharedCredentialsFile,
         "skipCredentialsValidation": args.skipCredentialsValidation,
         "skipMetadataApiCheck": args.skipMetadataApiCheck,
@@ -40,6 +48,26 @@ export interface GetS3ReferenceArgs {
      */
     accessKey?: string;
     /**
+     * The duration, in seconds, of the assume role session.
+     */
+    assumeRoleDurationSeconds?: number;
+    /**
+     * IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     */
+    assumeRolePolicy?: string;
+    /**
+     * Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     */
+    assumeRolePolicyArns?: string[];
+    /**
+     * Assume role session tags.
+     */
+    assumeRoleTags?: {[key: string]: string};
+    /**
+     * Assume role session tag keys to pass to any subsequent sessions.
+     */
+    assumeRoleTransitiveTagKeys?: string[];
+    /**
      * The name of the S3 bucket.
      */
     bucket: string;
@@ -51,6 +79,10 @@ export interface GetS3ReferenceArgs {
      * A custom endpoint for the S3 API.
      */
     endpoint?: string;
+    /**
+     * The external ID to use when assuming the role.
+     */
+    externalId?: string;
     /**
      * Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
      */
@@ -80,9 +112,17 @@ export interface GetS3ReferenceArgs {
      */
     region?: string;
     /**
+     * The ARN of an IAM Role to be assumed in order to read the state.
+     */
+    roleArn?: string;
+    /**
      * AWS secret key.
      */
     secretKey?: string;
+    /**
+     * The session name to use when assuming the role.
+     */
+    sessionName?: string;
     /**
      * Path to a shared credentials file.
      */
@@ -137,9 +177,15 @@ export function getS3ReferenceOutput(args: GetS3ReferenceOutputArgs, opts?: pulu
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("terraform:state:getS3Reference", {
         "accessKey": args.accessKey,
+        "assumeRoleDurationSeconds": args.assumeRoleDurationSeconds,
+        "assumeRolePolicy": args.assumeRolePolicy,
+        "assumeRolePolicyArns": args.assumeRolePolicyArns,
+        "assumeRoleTags": args.assumeRoleTags,
+        "assumeRoleTransitiveTagKeys": args.assumeRoleTransitiveTagKeys,
         "bucket": args.bucket,
         "encrypt": args.encrypt,
         "endpoint": args.endpoint,
+        "externalId": args.externalId,
         "forcePathStyle": args.forcePathStyle,
         "iamEndpoint": args.iamEndpoint,
         "key": args.key,
@@ -147,7 +193,9 @@ export function getS3ReferenceOutput(args: GetS3ReferenceOutputArgs, opts?: pulu
         "maxRetries": args.maxRetries,
         "profile": args.profile,
         "region": args.region,
+        "roleArn": args.roleArn,
         "secretKey": args.secretKey,
+        "sessionName": args.sessionName,
         "sharedCredentialsFile": args.sharedCredentialsFile,
         "skipCredentialsValidation": args.skipCredentialsValidation,
         "skipMetadataApiCheck": args.skipMetadataApiCheck,
@@ -166,6 +214,26 @@ export interface GetS3ReferenceOutputArgs {
      */
     accessKey?: pulumi.Input<string | undefined>;
     /**
+     * The duration, in seconds, of the assume role session.
+     */
+    assumeRoleDurationSeconds?: pulumi.Input<number | undefined>;
+    /**
+     * IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+     */
+    assumeRolePolicy?: pulumi.Input<string | undefined>;
+    /**
+     * Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+     */
+    assumeRolePolicyArns?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    /**
+     * Assume role session tags.
+     */
+    assumeRoleTags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    /**
+     * Assume role session tag keys to pass to any subsequent sessions.
+     */
+    assumeRoleTransitiveTagKeys?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    /**
      * The name of the S3 bucket.
      */
     bucket: pulumi.Input<string>;
@@ -177,6 +245,10 @@ export interface GetS3ReferenceOutputArgs {
      * A custom endpoint for the S3 API.
      */
     endpoint?: pulumi.Input<string | undefined>;
+    /**
+     * The external ID to use when assuming the role.
+     */
+    externalId?: pulumi.Input<string | undefined>;
     /**
      * Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
      */
@@ -206,9 +278,17 @@ export interface GetS3ReferenceOutputArgs {
      */
     region?: pulumi.Input<string | undefined>;
     /**
+     * The ARN of an IAM Role to be assumed in order to read the state.
+     */
+    roleArn?: pulumi.Input<string | undefined>;
+    /**
      * AWS secret key.
      */
     secretKey?: pulumi.Input<string | undefined>;
+    /**
+     * The session name to use when assuming the role.
+     */
+    sessionName?: pulumi.Input<string | undefined>;
     /**
      * Path to a shared credentials file.
      */

--- a/sdk/python/pulumi_terraform/state/get_s3_reference.py
+++ b/sdk/python/pulumi_terraform/state/get_s3_reference.py
@@ -50,9 +50,15 @@ class AwaitableGetS3ReferenceResult(GetS3ReferenceResult):
 
 
 def get_s3_reference(access_key: Optional[_builtins.str] = None,
+                     assume_role_duration_seconds: Optional[_builtins.int] = None,
+                     assume_role_policy: Optional[_builtins.str] = None,
+                     assume_role_policy_arns: Optional[Sequence[_builtins.str]] = None,
+                     assume_role_tags: Optional[Mapping[str, _builtins.str]] = None,
+                     assume_role_transitive_tag_keys: Optional[Sequence[_builtins.str]] = None,
                      bucket: Optional[_builtins.str] = None,
                      encrypt: Optional[_builtins.bool] = None,
                      endpoint: Optional[_builtins.str] = None,
+                     external_id: Optional[_builtins.str] = None,
                      force_path_style: Optional[_builtins.bool] = None,
                      iam_endpoint: Optional[_builtins.str] = None,
                      key: Optional[_builtins.str] = None,
@@ -60,7 +66,9 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
                      max_retries: Optional[_builtins.int] = None,
                      profile: Optional[_builtins.str] = None,
                      region: Optional[_builtins.str] = None,
+                     role_arn: Optional[_builtins.str] = None,
                      secret_key: Optional[_builtins.str] = None,
+                     session_name: Optional[_builtins.str] = None,
                      shared_credentials_file: Optional[_builtins.str] = None,
                      skip_credentials_validation: Optional[_builtins.bool] = None,
                      skip_metadata_api_check: Optional[_builtins.bool] = None,
@@ -75,9 +83,15 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
     Access state from an AWS S3 bucket.
 
     :param _builtins.str access_key: AWS access key.
+    :param _builtins.int assume_role_duration_seconds: The duration, in seconds, of the assume role session.
+    :param _builtins.str assume_role_policy: IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+    :param Sequence[_builtins.str] assume_role_policy_arns: Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+    :param Mapping[str, _builtins.str] assume_role_tags: Assume role session tags.
+    :param Sequence[_builtins.str] assume_role_transitive_tag_keys: Assume role session tag keys to pass to any subsequent sessions.
     :param _builtins.str bucket: The name of the S3 bucket.
     :param _builtins.bool encrypt: Whether to enable server side encryption of the state file.
     :param _builtins.str endpoint: A custom endpoint for the S3 API.
+    :param _builtins.str external_id: The external ID to use when assuming the role.
     :param _builtins.bool force_path_style: Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
     :param _builtins.str iam_endpoint: A custom endpoint for the IAM API.
     :param _builtins.str key: The path to the state file inside the bucket. When using a non-default workspace, the state path is /workspace_key_prefix/workspace_name/key.
@@ -85,7 +99,9 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
     :param _builtins.int max_retries: The maximum number of times an AWS API request is retried on retryable failure.
     :param _builtins.str profile: AWS profile name as set in the shared credentials file.
     :param _builtins.str region: AWS region of the S3 bucket. Falls back to the AWS_REGION or AWS_DEFAULT_REGION environment variables when unset.
+    :param _builtins.str role_arn: The ARN of an IAM Role to be assumed in order to read the state.
     :param _builtins.str secret_key: AWS secret key.
+    :param _builtins.str session_name: The session name to use when assuming the role.
     :param _builtins.str shared_credentials_file: Path to a shared credentials file.
     :param _builtins.bool skip_credentials_validation: Skip the credentials validation via the STS API.
     :param _builtins.bool skip_metadata_api_check: Skip the AWS Metadata API check.
@@ -98,9 +114,15 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
     """
     __args__ = dict()
     __args__['accessKey'] = access_key
+    __args__['assumeRoleDurationSeconds'] = assume_role_duration_seconds
+    __args__['assumeRolePolicy'] = assume_role_policy
+    __args__['assumeRolePolicyArns'] = assume_role_policy_arns
+    __args__['assumeRoleTags'] = assume_role_tags
+    __args__['assumeRoleTransitiveTagKeys'] = assume_role_transitive_tag_keys
     __args__['bucket'] = bucket
     __args__['encrypt'] = encrypt
     __args__['endpoint'] = endpoint
+    __args__['externalId'] = external_id
     __args__['forcePathStyle'] = force_path_style
     __args__['iamEndpoint'] = iam_endpoint
     __args__['key'] = key
@@ -108,7 +130,9 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
     __args__['maxRetries'] = max_retries
     __args__['profile'] = profile
     __args__['region'] = region
+    __args__['roleArn'] = role_arn
     __args__['secretKey'] = secret_key
+    __args__['sessionName'] = session_name
     __args__['sharedCredentialsFile'] = shared_credentials_file
     __args__['skipCredentialsValidation'] = skip_credentials_validation
     __args__['skipMetadataApiCheck'] = skip_metadata_api_check
@@ -124,9 +148,15 @@ def get_s3_reference(access_key: Optional[_builtins.str] = None,
     return AwaitableGetS3ReferenceResult(
         outputs=pulumi.get(__ret__, 'outputs'))
 def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                            assume_role_duration_seconds: pulumi.Input[Optional[Optional[_builtins.int]]] = None,
+                            assume_role_policy: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                            assume_role_policy_arns: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                            assume_role_tags: pulumi.Input[Optional[Optional[Mapping[str, _builtins.str]]]] = None,
+                            assume_role_transitive_tag_keys: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                             bucket: pulumi.Input[Optional[_builtins.str]] = None,
                             encrypt: pulumi.Input[Optional[Optional[_builtins.bool]]] = None,
                             endpoint: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                            external_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             force_path_style: pulumi.Input[Optional[Optional[_builtins.bool]]] = None,
                             iam_endpoint: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             key: pulumi.Input[Optional[_builtins.str]] = None,
@@ -134,7 +164,9 @@ def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins
                             max_retries: pulumi.Input[Optional[Optional[_builtins.int]]] = None,
                             profile: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             region: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                            role_arn: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             secret_key: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                            session_name: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             shared_credentials_file: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                             skip_credentials_validation: pulumi.Input[Optional[Optional[_builtins.bool]]] = None,
                             skip_metadata_api_check: pulumi.Input[Optional[Optional[_builtins.bool]]] = None,
@@ -149,9 +181,15 @@ def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins
     Access state from an AWS S3 bucket.
 
     :param _builtins.str access_key: AWS access key.
+    :param _builtins.int assume_role_duration_seconds: The duration, in seconds, of the assume role session.
+    :param _builtins.str assume_role_policy: IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+    :param Sequence[_builtins.str] assume_role_policy_arns: Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+    :param Mapping[str, _builtins.str] assume_role_tags: Assume role session tags.
+    :param Sequence[_builtins.str] assume_role_transitive_tag_keys: Assume role session tag keys to pass to any subsequent sessions.
     :param _builtins.str bucket: The name of the S3 bucket.
     :param _builtins.bool encrypt: Whether to enable server side encryption of the state file.
     :param _builtins.str endpoint: A custom endpoint for the S3 API.
+    :param _builtins.str external_id: The external ID to use when assuming the role.
     :param _builtins.bool force_path_style: Force s3 to use path-style addressing instead of virtual hosted-bucket addressing. Required by most S3-compatible stores.
     :param _builtins.str iam_endpoint: A custom endpoint for the IAM API.
     :param _builtins.str key: The path to the state file inside the bucket. When using a non-default workspace, the state path is /workspace_key_prefix/workspace_name/key.
@@ -159,7 +197,9 @@ def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins
     :param _builtins.int max_retries: The maximum number of times an AWS API request is retried on retryable failure.
     :param _builtins.str profile: AWS profile name as set in the shared credentials file.
     :param _builtins.str region: AWS region of the S3 bucket. Falls back to the AWS_REGION or AWS_DEFAULT_REGION environment variables when unset.
+    :param _builtins.str role_arn: The ARN of an IAM Role to be assumed in order to read the state.
     :param _builtins.str secret_key: AWS secret key.
+    :param _builtins.str session_name: The session name to use when assuming the role.
     :param _builtins.str shared_credentials_file: Path to a shared credentials file.
     :param _builtins.bool skip_credentials_validation: Skip the credentials validation via the STS API.
     :param _builtins.bool skip_metadata_api_check: Skip the AWS Metadata API check.
@@ -172,9 +212,15 @@ def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins
     """
     __args__ = dict()
     __args__['accessKey'] = access_key
+    __args__['assumeRoleDurationSeconds'] = assume_role_duration_seconds
+    __args__['assumeRolePolicy'] = assume_role_policy
+    __args__['assumeRolePolicyArns'] = assume_role_policy_arns
+    __args__['assumeRoleTags'] = assume_role_tags
+    __args__['assumeRoleTransitiveTagKeys'] = assume_role_transitive_tag_keys
     __args__['bucket'] = bucket
     __args__['encrypt'] = encrypt
     __args__['endpoint'] = endpoint
+    __args__['externalId'] = external_id
     __args__['forcePathStyle'] = force_path_style
     __args__['iamEndpoint'] = iam_endpoint
     __args__['key'] = key
@@ -182,7 +228,9 @@ def get_s3_reference_output(access_key: pulumi.Input[Optional[Optional[_builtins
     __args__['maxRetries'] = max_retries
     __args__['profile'] = profile
     __args__['region'] = region
+    __args__['roleArn'] = role_arn
     __args__['secretKey'] = secret_key
+    __args__['sessionName'] = session_name
     __args__['sharedCredentialsFile'] = shared_credentials_file
     __args__['skipCredentialsValidation'] = skip_credentials_validation
     __args__['skipMetadataApiCheck'] = skip_metadata_api_check


### PR DESCRIPTION
The v5 SDK's `RemoteStateReference` supported reading state via an assumed IAM role (`roleArn`, `sessionName`, `externalId`), but the v6 rewrite dropped those arguments, leaving assume-role configurations inexpressible — one of the blockers keeping users in https://github.com/pulumi/pulumi-terraform/issues/809 on the v5 SDK.

This exposes all eight assume-role arguments from the pinned Terraform 1.5.7 s3 backend schema:

- `roleArn`
- `sessionName`
- `externalId`
- `assumeRoleDurationSeconds`
- `assumeRolePolicy`
- `assumeRolePolicyArns`
- `assumeRoleTags`
- `assumeRoleTransitiveTagKeys`

## Testing

`TestStateReferenceReadS3AssumeRole` seeds a MinIO container with real Terraform state (via `tofu apply`), then invokes `getS3Reference` with `roleArn` set and `stsEndpoint` pointed at MinIO's STS API. The backend calls STS `AssumeRole` and reads the state with the returned temporary credentials.

Verified the test actually exercises the assume-role path: with `roleArn` set and the STS endpoint pointed at a dead port, the read fails with a credential-chain error, so `role_arn` drives a real `AssumeRole` call rather than silently falling back to the static credentials.

Part of #809 (the azurerm backend gap remains).