### PR TITLE
Test that null state outputs are distinguished from missing ones

### DIFF
--- a/provider/state_reference/local.go
+++ b/provider/state_reference/local.go
@@ -23,6 +23,9 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
+// localPathAttribute is the local backend's config attribute naming the state file.
+const localPathAttribute = "path"
+
 type GetLocalReference struct{}
 
 var _ = (infer.Annotated)((*GetLocalReference)(nil))
@@ -48,8 +51,8 @@ func (r *GetLocalReference) Invoke(
 	req infer.FunctionRequest[GetLocalReferenceArgs],
 ) (infer.FunctionResponse[StateReferenceOutputs], error) {
 	results, err := shim.StateReferenceRead(ctx, "local", "", map[string]cty.Value{
-		"path":          ctyStringOrNil(req.Input.Path),
-		"workspace_dir": ctyStringOrNil(req.Input.WorkspaceDir),
+		localPathAttribute: ctyStringOrNil(req.Input.Path),
+		"workspace_dir":    ctyStringOrNil(req.Input.WorkspaceDir),
 	})
 
 	return infer.FunctionResponse[StateReferenceOutputs]{Output: StateReferenceOutputs{results}}, err

--- a/provider/state_reference/local_test.go
+++ b/provider/state_reference/local_test.go
@@ -1,0 +1,99 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// TestStateReferenceReadLocalNullOutput reads local state whose outputs contain a
+// null value and checks that null survives to the RPC response instead of being
+// conflated with "not present".
+//
+// The test goes through [p.RawServer] because the null/missing distinction is a
+// property of the gRPC marshaling layer: before pulumi-go-provider v1.4.1 that
+// layer dropped null-valued keys (SkipNulls), so null_field below vanished from
+// the response.
+func TestStateReferenceReadLocalNullOutput(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Terraform elides top-level null outputs from state, so the realistic way a
+	// null reaches a state file is inside an object output.
+	config := `
+output "present" {
+  value = "hello"
+}
+
+output "obj" {
+  value = {
+    set_field  = "yes"
+    null_field = null
+  }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(config), 0o600))
+	tofu := func(args ...string) {
+		cmd := exec.CommandContext(ctx, "tofu", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "tofu %v failed:\n%s", args, out)
+	}
+	tofu("init", "-input=false")
+	tofu("apply", "-auto-approve", "-input=false")
+
+	InitTfBackend()
+	prov := infer.Provider(infer.Options{
+		Functions: []infer.InferredFunction{infer.Function(&GetLocalReference{})},
+		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"state_reference": "state"},
+	})
+	server, err := p.RawServer("terraform", "6.0.0", prov)(nil)
+	require.NoError(t, err)
+
+	args, err := structpb.NewStruct(map[string]any{
+		localPathAttribute: filepath.Join(dir, "terraform.tfstate"),
+	})
+	require.NoError(t, err)
+
+	resp, err := server.Invoke(ctx, &pulumirpc.InvokeRequest{
+		Tok:  "terraform:state:getLocalReference",
+		Args: args,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetFailures())
+
+	assert.Equal(t, map[string]any{
+		"outputs": map[string]any{
+			"present": "hello",
+			"obj": map[string]any{
+				"set_field":  "yes",
+				"null_field": nil,
+			},
+		},
+	}, resp.GetReturn().AsMap())
+}

--- a/provider/state_reference/remote_test.go
+++ b/provider/state_reference/remote_test.go
@@ -66,7 +66,7 @@ func TestStateReferenceReadLocal(t *testing.T) {
 
 	outputs, err := shim.StateReferenceRead(
 		context.Background(), "local", defaultWorkspace, map[string]cty.Value{
-			"path": cty.StringVal("testdata/test.tfstate"),
+			localPathAttribute: cty.StringVal("testdata/test.tfstate"),
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Adds a regression test reading local Terraform state whose outputs contain a null value, asserting the null key survives to the RPC invoke response as `null` instead of being dropped (i.e. conflated with "not present").

Two details worth noting:

- Terraform elides **top-level** null outputs from state entirely (verified with `tofu apply`), so the realistic way a null reaches a state file is inside an object output — the test seeds `obj = { set_field = "yes", null_field = null }` via a real `tofu apply`.
- The test invokes `terraform:state:getLocalReference` through `p.RawServer` rather than calling the function struct directly, because the null/missing distinction is a property of the gRPC marshaling layer: the shim already preserved nulls, but pulumi-go-provider marshaled responses with `SkipNulls: true` until [v1.4.1 removed it](https://github.com/pulumi/pulumi-go-provider/compare/v1.4.0...v1.4.1). The in-process `integration` server bypasses that layer and would not catch the bug.

The `localPathAttribute` constant deduplicates the `"path"` literal that now occurs three times in the package (goconst).

## Verification

- On master (pulumi-go-provider v1.4.1): test **passes**.
- With `go.mod` downgraded to pulumi-go-provider v1.4.0: test **fails** exactly as expected — `null_field` vanishes from `obj`:
  ```
  actual: map[string]interface {}{"outputs":map[string]interface {}{"obj":map[string]interface {}{"set_field":"yes"}, "present":"hello"}}
  ```
- `golangci-lint run provider/state_reference/` clean; full `go test ./provider/state_reference/` passes (10 tests).